### PR TITLE
Make available the list of known decay models

### DIFF
--- a/decaylanguage/dec/__init__.py
+++ b/decaylanguage/dec/__init__.py
@@ -1,3 +1,5 @@
 from __future__ import absolute_import
 
 from .dec import DecFileParser
+
+from .enums import known_decay_models

--- a/decaylanguage/dec/enums.py
+++ b/decaylanguage/dec/enums.py
@@ -1,5 +1,5 @@
 """
-Collection of enums to help characterising .dec decay files.
+Collection of enums and info to help characterising .dec decay files.
 """
 
 # Backport needed if Python 2 is used
@@ -9,3 +9,49 @@ from enum import IntEnum
 class PhotosEnum(IntEnum):
     no = 0
     yes = 1
+
+
+# This list should match the list specified in the decay file parser file
+# 'decaylanguage/data/decfile.lark'!
+known_decay_models = (
+    "BaryonPCR",
+    "BTO3PI_CP",
+    "BTOSLLALI",
+    "BTOSLLBALL",
+    "BTOXSGAMMA",
+    "BTOXSLL",
+    "CB3PI-MPP",
+    "CB3PI-P00",
+    "D_DALITZ",
+    "ETA_DALITZ",
+    "GOITY_ROBERTS",
+    "HELAMP",
+    "HQET",
+    "ISGW2",
+    "LbAmpGen",
+    "OMEGA_DALITZ",
+    "PARTWAVE",
+    "PHSP",
+    "PI0_DALITZ",
+    "PYTHIA",
+    "SLN",
+    "SSD_CP",
+    "STS",
+    "SVP_HELAMP",
+    "SVS",
+    "SVV_HELAMP",
+    "TAUHADNU",
+    "TAULNUNU",
+    "TAUSCALARNU",
+    "TAUVECTORNU",
+    "TSS",
+    "TVS_PWAVE",
+    "VLL",
+    "VSP_PWAVE",
+    "VSS",
+    "VSS_BMIX",
+    "VUB",
+    "VVP",
+    "VVPIPI",
+    "VVS_PWAVE",
+    )


### PR DESCRIPTION
I reckon this can be useful to have available. I put it in the `enums.py` submodule to avoid having another trivial file. But we can move this to a `defs.py` file or alike, if you prefer.