### PR TITLE
DecayMode class

### DIFF
--- a/decaylanguage/decay/decay.py
+++ b/decaylanguage/decay/decay.py
@@ -87,10 +87,36 @@ class DecayMode(object):
         """
         Default constructor.
 
-        Example
+        Parameters
+        ----------
+        bf: float, optional, default=0
+            Decay mode branching fraction
+        daughters: DaughtersDict, optional, default=None
+            The final-state particles
+        info: keyword arguments, optional
+            Decay mode model information and/or user metadata (aka extra info)
+            By default the following elements are always created:
+            dict(model=None, model_params=None)
+            The user can provide any metadata, see the examples below.
+
+        Examples
         --------
         >>> # A 'default' and hence empty, decay mode
         >>> dm = DecayMode()
+
+        >>> # Decay mode with minimal input information
+        >>> dd = DaughtersDict('K+ K-')
+        >>> dm = DecayMode(0.5, dd)
+
+        >>> # Decay mode with decay model information
+        >>> dd = DaughtersDict('pi- pi0 nu_tau')
+        >>> dm = DecayMode(0.2551, dd,
+                           model='TAUHADNU',
+                           model_params=[-0.108, 0.775, 0.149, 1.364, 0.400])
+
+        >>> # Decay mode with user metadata
+        >>> dd = DaughtersDict('K+ K-')
+        >>> dm = DecayMode(0.5, dd, model='PHSP', study='toy', year=2019)
         """
         self.bf = bf
         self.daughters = daughters if daughters is not None else DaughtersDict()
@@ -100,6 +126,13 @@ class DecayMode(object):
 
     @classmethod
     def from_pdgids(cls, bf, daughters, **info):
+        """
+        Constructor for a final state given as a list of particle PDG IDs.
+
+        Examples
+        --------
+        >>> dm = DecayMode.from_pdgids(0.5, [321, -321])
+        """
         # Check inputs
         try:
             from particle import Particle, ParticleNotFound

--- a/decaylanguage/decay/decay.py
+++ b/decaylanguage/decay/decay.py
@@ -149,9 +149,7 @@ class DecayMode(object):
         Make a nice high-density string for all decay-mode properties and info.
         """
         val = """Daughters: {daughters} , BF: {bf:<15.8g}
-    Decay model: {model} {model_params}
-    Extra info:
-""".format(daughters=' '.join(self.daughters),
+    Decay model: {model} {model_params}""".format(daughters=' '.join(self.daughters),
            bf=self.bf,
            model=self.metadata['model'],
            model_params=self.metadata['model_params']
@@ -159,6 +157,8 @@ class DecayMode(object):
 
         keys = [k for k in self.metadata
               if k not in ('model', 'model_params')]
+        if len(keys) > 0:
+            val += "\n    Extra info:\n"
         for key in keys:
             val += "        {k}: {v}\n".format(k=key, v=self.metadata[key])
 

--- a/tests/decay/test_decay.py
+++ b/tests/decay/test_decay.py
@@ -97,7 +97,7 @@ def test_DecayMode_describe_with_extra_info():
 def test_DecayMode_string_repr():
     dd = DaughtersDict('p p~ K+ pi-')
     dm = DecayMode(1.e-6, dd, model='PHSP')
-    assert dm.__str__() == "<DecayMode: daughters=K+ p pi- p~, BF=1e-06>"
+    assert str(dm) == "<DecayMode: daughters=K+ p pi- p~, BF=1e-06>"
 
 
 def test_DecayMode_number_of_final_states():

--- a/tests/decay/test_decay.py
+++ b/tests/decay/test_decay.py
@@ -70,14 +70,7 @@ def test_DecayMode_constructor_with_model_info():
                            'model_params': [-0.108, 0.775, 0.149, 1.364, 0.4]}
 
 
-def test_DecayMode_constructor_with_model_info():
-    dd = DaughtersDict('pi- pi0 nu_tau')
-    dm = DecayMode(0.2551, dd, model='TAUHADNU', model_params=[-0.108, 0.775, 0.149, 1.364, 0.400])
-    description = """Daughters: pi- pi0 nu_tau,
-       BF: 0.2551          decay model: TAUHADNU [-0.108, 0.775, 0.149, 1.364, 0.4]"""
-    assert dm.describe() == description
-
-def test_DecayMode_constructor_with_model_info():
+def test_DecayMode_constructor_with_user_model_info():
     dd = DaughtersDict('K+ K-')
     dm = DecayMode(0.5, dd, model='PHSP', study='toy', year=2019)
     assert dm.metadata == {'model': 'PHSP',
@@ -86,7 +79,15 @@ def test_DecayMode_constructor_with_model_info():
                            'year': 2019}
 
 
-def test_DecayMode_describe():
+def test_DecayMode_describe_simple():
+    dd = DaughtersDict('pi- pi0 nu_tau')
+    dm = DecayMode(0.2551, dd, model='TAUHADNU', model_params=[-0.108, 0.775, 0.149, 1.364, 0.400])
+    description = """Daughters: pi- pi0 nu_tau,
+       BF: 0.2551          decay model: TAUHADNU [-0.108, 0.775, 0.149, 1.364, 0.4]"""
+    assert dm.describe() == description
+
+
+def test_DecayMode_describe_with_extra_info():
     dd = DaughtersDict('K+ K-')
     dm = DecayMode(1.e-6, dd, model='PHSP', study='toy', year=2019)
     assert """
@@ -95,7 +96,7 @@ def test_DecayMode_describe():
         year: 2019""" in dm.describe()
 
 
-def test_DaughtersDict_string_repr():
+def test_DecayMode_string_repr():
     dd = DaughtersDict('p p~ K+ pi-')
     dm = DecayMode(1.e-6, dd, model='PHSP')
     assert dm.__str__() == "<DecayMode: daughters=K+ p pi- p~, BF=1e-06>"

--- a/tests/decay/test_decay.py
+++ b/tests/decay/test_decay.py
@@ -82,8 +82,7 @@ def test_DecayMode_constructor_with_user_model_info():
 def test_DecayMode_describe_simple():
     dd = DaughtersDict('pi- pi0 nu_tau')
     dm = DecayMode(0.2551, dd, model='TAUHADNU', model_params=[-0.108, 0.775, 0.149, 1.364, 0.400])
-    description = """Daughters: pi- pi0 nu_tau,
-       BF: 0.2551          decay model: TAUHADNU [-0.108, 0.775, 0.149, 1.364, 0.4]"""
+    description = 'Daughters: pi- pi0 nu_tau , BF: 0.2551         \n    Decay model: TAUHADNU [-0.108, 0.775, 0.149, 1.364, 0.4]'
     assert dm.describe() == description
 
 

--- a/tests/decay/test_decay.py
+++ b/tests/decay/test_decay.py
@@ -82,8 +82,8 @@ def test_DecayMode_constructor_with_user_model_info():
 def test_DecayMode_describe_simple():
     dd = DaughtersDict('pi- pi0 nu_tau')
     dm = DecayMode(0.2551, dd, model='TAUHADNU', model_params=[-0.108, 0.775, 0.149, 1.364, 0.400])
-    description = 'Daughters: pi- pi0 nu_tau , BF: 0.2551         \n    Decay model: TAUHADNU [-0.108, 0.775, 0.149, 1.364, 0.4]'
-    assert dm.describe() == description
+    assert 'BF: 0.2551' in dm.describe()
+    assert 'Decay model: TAUHADNU [-0.108, 0.775, 0.149, 1.364, 0.4]' in dm.describe()
 
 
 def test_DecayMode_describe_with_extra_info():

--- a/tests/decay/test_decay.py
+++ b/tests/decay/test_decay.py
@@ -89,10 +89,9 @@ def test_DecayMode_describe_simple():
 def test_DecayMode_describe_with_extra_info():
     dd = DaughtersDict('K+ K-')
     dm = DecayMode(1.e-6, dd, model='PHSP', study='toy', year=2019)
-    assert """
-    Extra info:
-        study: toy
-        year: 2019""" in dm.describe()
+    assert 'Extra info:' in dm.describe()
+    assert 'study: toy' in dm.describe()
+    assert 'year: 2019' in dm.describe()
 
 
 def test_DecayMode_string_repr():

--- a/tests/decay/test_decay.py
+++ b/tests/decay/test_decay.py
@@ -1,4 +1,5 @@
 from decaylanguage.decay.decay import DaughtersDict
+from decaylanguage.decay.decay import DecayMode
 
 
 def test_DaughtersDict_constructor_from_dict():
@@ -36,3 +37,71 @@ def test_DaughtersDict_add():
 def test_DaughtersDict_to_string():
     dd1 = DaughtersDict({'K+': 1, 'K-': 2, 'pi0': 3})
     assert dd1.to_string() == 'K+ K- K- pi0 pi0 pi0'
+
+
+def test_DecayMode_constructor_default():
+    dm = DecayMode()
+    assert dm.bf == 0
+    assert dm.daughters == DaughtersDict()
+    assert dm.metadata == dict(model=None, model_params=None)
+
+
+def test_DecayMode_constructor_simple():
+    dd = DaughtersDict('K+ K-')
+    dm = DecayMode(0.1234, dd)
+    assert dm.bf == 0.1234
+    assert dm.daughters == DaughtersDict('K+ K-')
+    assert dm.metadata == dict(model=None, model_params=None)
+
+
+def test_DecayMode_constructor_from_pdgids():
+    dm = DecayMode.from_pdgids(0.5, [321, -321],
+                               model='TAUHADNU',
+                               model_params=[-0.108, 0.775, 0.149, 1.364, 0.400])
+    assert dm.daughters == DaughtersDict('K+ K-')
+
+
+def test_DecayMode_constructor_with_model_info():
+    dd = DaughtersDict('pi- pi0 nu_tau')
+    dm = DecayMode(0.2551, dd,
+                   model='TAUHADNU',
+                   model_params=[-0.108, 0.775, 0.149, 1.364, 0.400])
+    assert dm.metadata == {'model': 'TAUHADNU',
+                           'model_params': [-0.108, 0.775, 0.149, 1.364, 0.4]}
+
+
+def test_DecayMode_constructor_with_model_info():
+    dd = DaughtersDict('pi- pi0 nu_tau')
+    dm = DecayMode(0.2551, dd, model='TAUHADNU', model_params=[-0.108, 0.775, 0.149, 1.364, 0.400])
+    description = """Daughters: pi- pi0 nu_tau,
+       BF: 0.2551          decay model: TAUHADNU [-0.108, 0.775, 0.149, 1.364, 0.4]"""
+    assert dm.describe() == description
+
+def test_DecayMode_constructor_with_model_info():
+    dd = DaughtersDict('K+ K-')
+    dm = DecayMode(0.5, dd, model='PHSP', study='toy', year=2019)
+    assert dm.metadata == {'model': 'PHSP',
+                           'model_params': None,
+                           'study': 'toy',
+                           'year': 2019}
+
+
+def test_DecayMode_describe():
+    dd = DaughtersDict('K+ K-')
+    dm = DecayMode(1.e-6, dd, model='PHSP', study='toy', year=2019)
+    assert """
+    Extra info:
+        study: toy
+        year: 2019""" in dm.describe()
+
+
+def test_DaughtersDict_string_repr():
+    dd = DaughtersDict('p p~ K+ pi-')
+    dm = DecayMode(1.e-6, dd, model='PHSP')
+    assert dm.__str__() == "<DecayMode: daughters=K+ p pi- p~, BF=1e-06>"
+
+
+def test_DecayMode_number_of_final_states():
+    dd = DaughtersDict('p p~ K+ pi-')
+    dm = DecayMode(1.e-6, dd, model='PHSP')
+    assert len(dm) == 4


### PR DESCRIPTION
This is the second class for the design of a digital representation of full decay chains.
Take it as the remaining building block. It's a convenient way to store decay modes, making use of the new DaughtersDict class. The mother particle is not part of / stored in the decay mode as that's common to various decay modes, by construction - no need to duplicate info.

I will need to add some more documentation. Otherwise that's it. In particular, the test suite seems comprehensive already.