### PR TITLE
Image link in README made to display on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![DecayLanguage](https://github.com/scikit-hep/decaylanguage/raw/master/images/DecayLanguage.png)](http://decaylanguage.readthedocs.io/en/latest/)
+[![DecayLanguage](https://raw.githubusercontent.com/scikit-hep/decaylanguage/master/images/DecayLanguage.png)](http://decaylanguage.readthedocs.io/en/latest/)
 
 ## DecayLanguage: describe, manipulate and convert particle decays
 


### PR DESCRIPTION
This should fix the fact that the logo does not show on PyPI for release 0.3.0.