### PR TITLE
Temporarily remove Python 2.7 checks on Linux, because of issue in Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,8 +19,8 @@ jobs:
     vmImage: 'ubuntu-16.04'
   strategy:
     matrix:
-      Python27:
-        python.version: '2.7'
+#      Python27:
+#        python.version: '2.7'
       Python35:
         python.version: '3.5'
       Python36:


### PR DESCRIPTION
@henryiii, this is a temporary workaround for https://github.com/scikit-hep/decaylanguage/issues/55, as I want to make a new release and the failure in Azure is annoying.