### PR TITLE
Rename DecFileParser.build_decay_chain() to DecFileParser.build_decay_chains()

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ from decaylanguage import DecayChainViewer
 
 # Build the D*+ decay chain representation setting the D+ and D0 mesons to stable,
 # to avoid too cluttered an image
-d = parser.build_decay_chain('D*+', stable_particles=['D+', 'D0'])
+d = parser.build_decay_chains('D*+', stable_particles=['D+', 'D0'])
 DecayChainViewer(d)  # works in a notebook
 ```
 

--- a/decaylanguage/dec/dec.py
+++ b/decaylanguage/dec/dec.py
@@ -571,9 +571,9 @@ All but the first occurrence will be discarded/removed ...""".format(', '.join(d
             print('%12g : %50s %15s %s' % (dm_details[0], '  '.\
                 join(p for p in dm_details[1]), dm_details[2], dm_details[3]))
 
-    def build_decay_chain(self, mother, stable_particles=[]):
+    def build_decay_chains(self, mother, stable_particles=[]):
         """
-        Iteratively build the whole decay chain of a given mother particle,
+        Iteratively build the entire decay chains of a given mother particle,
         optionally considering, on the fly, certain particles as stable.
         This way, for example, only the B -> D E F part in a decay chain
         A -> B (-> D E F (-> G H)) C
@@ -584,7 +584,8 @@ All but the first occurrence will be discarded/removed ...""".format(', '.join(d
         mother: str
             Input mother particle name.
         stable_particles: iterable, optional, default=[]
-            If provided, stops the decay-chain parsing, taking the "list" as particles to be considered stable.
+            If provided, stops the decay-chain parsing,
+            taking the "list" as particles to be considered stable.
 
         Returns
         -------
@@ -602,7 +603,7 @@ All but the first occurrence will be discarded/removed ...""".format(', '.join(d
         --------
         >>> parser = DecFileParser('a-Dplus-decay-file.dec')
         >>> parser.parse()
-        >>> parser.build_decay_chain('D+')
+        >>> parser.build_decay_chains('D+')
         {'D+': [{'bf': 1.0,
            'fs': ['K-',
             'pi+',
@@ -622,7 +623,7 @@ All but the first occurrence will be discarded/removed ...""".format(', '.join(d
               {'bf': 6.5e-08, 'fs': ['e+', 'e-'], 'm': 'PHSP', 'mp': ''}]}],
            'm': 'PHSP',
            'mp': ''}]}
-        >>> p.build_decay_chain('D+', stable_particles=['pi0'])
+        >>> p.build_decay_chains('D+', stable_particles=['pi0'])
         {'D+': [{'bf': 1.0, 'fs': ['K-', 'pi+', 'pi+', 'pi0'], 'm': 'PHSP', 'mp': ''}]}
         """
         keys = ('bf', 'fs', 'm', 'mp')
@@ -641,7 +642,7 @@ All but the first occurrence will be discarded/removed ...""".format(', '.join(d
                     # if fs does not have decays defined in the parsed file
                     _n_dms = len(self._find_decay_modes(fs))
 
-                    _info = self.build_decay_chain(fs, stable_particles)
+                    _info = self.build_decay_chains(fs, stable_particles)
                     d['fs'][i] = _info
                 except DecayNotFound:
                     pass

--- a/decaylanguage/decay/viewer.py
+++ b/decaylanguage/decay/viewer.py
@@ -36,7 +36,7 @@ class DecayChainViewer(object):
     -------
     >>> dfp = DecFileParser('my-Dst-decay-file.dec')
     >>> dfp.parse()
-    >>> chain = dfp.build_decay_chain('D*+')
+    >>> chain = dfp.build_decay_chains('D*+')
     >>> dcv = DecayChainViewer(chain)
     >>> dcv  # display the SVG figure in a notebook
     """

--- a/notebooks/DecayLanguageDemo.ipynb
+++ b/notebooks/DecayLanguageDemo.ipynb
@@ -232,7 +232,7 @@
    },
    "outputs": [],
    "source": [
-    "d = parser.build_decay_chain('D+')\n",
+    "d = parser.build_decay_chains('D+')\n",
     "d"
    ]
   },
@@ -255,7 +255,7 @@
    },
    "outputs": [],
    "source": [
-    "d = parser.build_decay_chain('D*+')\n",
+    "d = parser.build_decay_chains('D*+')\n",
     "DecayChainViewer(d)"
    ]
   },
@@ -269,7 +269,7 @@
    },
    "outputs": [],
    "source": [
-    "d = parser.build_decay_chain('D*+', stable_particles=['D+'])\n",
+    "d = parser.build_decay_chains('D*+', stable_particles=['D+'])\n",
     "DecayChainViewer(d)"
    ]
   },
@@ -299,7 +299,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d = parser.build_decay_chain('D*-')\n",
+    "d = parser.build_decay_chains('D*-')\n",
     "DecayChainViewer(d)"
    ]
   },

--- a/tests/dec/test_dec.py
+++ b/tests/dec/test_dec.py
@@ -263,12 +263,12 @@ def test_duplicate_decay_definitions():
     assert p.list_decay_mother_names() == ['Sigma(1775)0', 'anti-Sigma(1775)0']
 
 
-def test_build_decay_chain():
+def test_build_decay_chains():
     p = DecFileParser(DIR / '../data/test_example_Dst.dec')
     p.parse()
 
     output = {'D+': [{'bf': 1.0, 'fs': ['K-', 'pi+', 'pi+', 'pi0'], 'm': 'PHSP', 'mp': ''}]}
-    assert p.build_decay_chain('D+', stable_particles=['pi0']) == output
+    assert p.build_decay_chains('D+', stable_particles=['pi0']) == output
 
 
 def test_Lark_DecayModelParamValueReplacement_Visitor_no_params():

--- a/tests/decay/test_viewer.py
+++ b/tests/decay/test_viewer.py
@@ -24,7 +24,7 @@ def test_single_decay():
     p = DecFileParser(DIR / '../data/test_example_Dst.dec')
     p.parse()
 
-    chain = p.build_decay_chain('D*+', stable_particles=['D+', 'D0', 'pi0'])
+    chain = p.build_decay_chains('D*+', stable_particles=['D+', 'D0', 'pi0'])
     dcv = DecayChainViewer(chain)
     graph_output_as_dot = dcv.to_string()
 
@@ -37,7 +37,7 @@ def test_simple_decay_chain():
     p = DecFileParser(DIR / '../data/test_example_Dst.dec')
     p.parse()
 
-    chain = p.build_decay_chain('D*+')
+    chain = p.build_decay_chains('D*+')
     dcv = DecayChainViewer(chain)
     graph_output_as_dot = dcv.to_string()
 
@@ -69,7 +69,7 @@ def test_duplicate_arrows(decfilepath, signal_mother):
     p = DecFileParser(decfilepath, DIR / '../../decaylanguage/data/DECAY_LHCB.DEC')
     p.parse()
 
-    chain = p.build_decay_chain(signal_mother)
+    chain = p.build_decay_chains(signal_mother)
     dcv = DecayChainViewer(chain)
     graph_output_as_dot = dcv.to_string()
 
@@ -81,7 +81,7 @@ def test_init_non_defaults():
     p = DecFileParser(DIR / '../data/test_example_Dst.dec')
     p.parse()
 
-    chain = p.build_decay_chain('D*+')
+    chain = p.build_decay_chains('D*+')
     dcv = DecayChainViewer(chain, graph_name='TEST', rankdir='TB')
 
     assert dcv.graph.get_name() == 'TEST'


### PR DESCRIPTION
Trivial rename - I think this makes sense because the method effectively provides a series of defined (and parsed) decay chains of a given mother particle.