### PR TITLE
Only export DecayChainViewer if available

### DIFF
--- a/decaylanguage/decay/__init__.py
+++ b/decaylanguage/decay/__init__.py
@@ -1,4 +1,7 @@
 
 from .decay import DaughtersDict, DecayMode, DecayChain
 
-from .viewer import DecayChainViewer
+try:
+    from .viewer import DecayChainViewer
+except ImportError:
+    pass


### PR DESCRIPTION
DecayChainViewer will not be available at the top level if pydot is not available. See #99.