### PR TITLE
Make pydot required, bump version to 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 0.6.2 (2020-06-05)
+
+* Dependencies:
+  - Package dependency on ``pydot`` made a requirement.
+
+
 ## Version 0.6.1 (2020-01-15)
 
 * Parsing of decay files (aka .dec files):

--- a/decaylanguage/_version.py
+++ b/decaylanguage/_version.py
@@ -4,7 +4,7 @@
 # or https://github.com/scikit-hep/decaylanguage for details.
 
 
-__version__ = '0.6.1'
+__version__ = '0.6.2'
 
 version = __version__
 version_info = __version__.split('.')

--- a/decaylanguage/decay/__init__.py
+++ b/decaylanguage/decay/__init__.py
@@ -1,7 +1,4 @@
 
 from .decay import DaughtersDict, DecayMode, DecayChain
 
-try:
-    from .viewer import DecayChainViewer
-except ImportError:
-    pass
+from .viewer import DecayChainViewer

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ INSTALL_REQUIRES = [
     'enum34>=1.1; python_version<"3.4"',
     'importlib_resources>=1.0; python_version<"3.7"',
     'cachetools; python_version<"3.3"',
-    'particle==0.9.*'
+    'particle==0.9.*',
+    'pydot'
 ]
 
 needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
@@ -54,8 +55,8 @@ def get_version():
     return g["__version__"]
 
 extras = {
-    'test': ['pytest', 'pydot'],
-    'notebook': ['graphviz', 'pydot'],
+    'test': ['pytest'],
+    'notebook': ['graphviz'],
 }
 
 setup(


### PR DESCRIPTION
Fixes https://github.com/scikit-hep/decaylanguage/issues/99.