### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
 # Changelog
 
-## Version 0.7.0
-
-Under development.
+## Version 0.7.0 (2020-08-13)
 
 * Dependencies:
-  - Package dependent on ``Particle`` version 0.10.
+  - Package dependent on ``Particle`` version 0.11.
   - Dependencies on `lark-parser` and others upgraded.
 
 

--- a/decaylanguage/_version.py
+++ b/decaylanguage/_version.py
@@ -4,7 +4,7 @@
 # or https://github.com/scikit-hep/decaylanguage for details.
 
 
-__version__ = '0.6.2'
+__version__ = '0.7.0'
 
 version = __version__
 version_info = __version__.split('.')

--- a/decaylanguage/modeling/ampgentransform.py
+++ b/decaylanguage/modeling/ampgentransform.py
@@ -6,7 +6,7 @@
 from lark import Transformer, Tree
 
 def get_from_parser(parser, key):
-    return [v.children for v in parser.find_data(key)]
+    return [v.children for v in list(parser.find_data(key))]
 
 class AmpGenTransformer(Transformer):
     def constant(self, lines):

--- a/decaylanguage/modeling/ampgentransform.py
+++ b/decaylanguage/modeling/ampgentransform.py
@@ -6,7 +6,7 @@
 from lark import Transformer, Tree
 
 def get_from_parser(parser, key):
-    return [v.children for v in list(parser.find_data(key))]
+    return [v.children for v in parser.find_data(key)]
 
 class AmpGenTransformer(Transformer):
     def constant(self, lines):

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - pip:
     - hepunits>=1.2.0
     - particle==0.11.*
-    - lark-parser>=0.8.0
+    - lark-parser==0.8.*
     - plumbum>=1.6.9
     - RISE
     - graphviz

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - pydot>=1.3.0
   - pip:
     - hepunits>=1.2.0
-    - particle==0.10.*
+    - particle==0.11.*
     - lark-parser>=0.8.0
     - plumbum>=1.6.9
     - RISE

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - pip:
     - hepunits>=1.2.0
     - particle==0.11.*
-    - lark-parser==0.8.*
+    - lark-parser>=0.8.0,<0.8.6
     - plumbum>=1.6.9
     - RISE
     - graphviz

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ INSTALL_REQUIRES = [
     'numpy>=1.12',
     'pandas>=0.22',
     'six>=1.11',
-    'lark-parser>=0.8.0',
+    'lark-parser==0.8.*',
     'pathlib2>=2.3; python_version<"3.5"',
     'enum34>=1.1; python_version<"3.4"',
     'importlib_resources>=1.0; python_version<"3.7"',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ INSTALL_REQUIRES = [
     'numpy>=1.12',
     'pandas>=0.22',
     'six>=1.11',
-    'lark-parser==0.8.*',
+    'lark-parser>=0.8.0, <0.8.6',
     'pathlib2>=2.3; python_version<"3.5"',
     'enum34>=1.1; python_version<"3.4"',
     'importlib_resources>=1.0; python_version<"3.7"',


### PR DESCRIPTION
FYI @henryiii - so it seems that we never released a version compatible with `Particle` v0.10. At this stage, and given that v0.11.0 is best, it makes sense to simply release on the later version.