### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 0.8.0 (2020-09-29)
+
+* Dependencies:
+  - Package dependent on ``Particle`` version 0.12.
+
 ## Version 0.7.0 (2020-08-13)
 
 * Dependencies:

--- a/decaylanguage/_version.py
+++ b/decaylanguage/_version.py
@@ -4,7 +4,7 @@
 # or https://github.com/scikit-hep/decaylanguage for details.
 
 
-__version__ = '0.7.2'
+__version__ = '0.8.0'
 
 version = __version__
 version_info = __version__.split('.')

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - pydot>=1.3.0
   - pip:
     - hepunits>=1.2.0
-    - particle==0.11.*
+    - particle==0.12.*
     - lark-parser>=0.8.0,<0.8.6
     - plumbum>=1.6.9
     - RISE

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ INSTALL_REQUIRES = [
     'enum34>=1.1; python_version<"3.4"',
     'importlib_resources>=1.0; python_version<"3.7"',
     'cachetools; python_version<"3.3"',
-    'particle==0.11.*',
+    'particle==0.12.*',
     'pydot'
 ]
 


### PR DESCRIPTION
A simple update of the dependency on `Particle`, from 0.11 to the newly released 0.12.