### PR TITLE
Add tests of Python 3.8 and 3.9 on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,10 @@ jobs:
         python.version: '2.7'
       Python37:
         python.version: '3.7'
+      Python38:
+        python.version: '3.8'
+      Python39:
+        python.version: '3.9'
 
   steps:
     - template: .ci/azure-steps.yml


### PR DESCRIPTION
At the moment we have a mix of tests. Something to improve at some stage. In any case it is important to have tests for Python 3.8 and 3.9 on Windows.