### PR TITLE
Release 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.10.1 (2020-12-10)
+
+* Environment YAML file updated to ``Particle`` version 0.14.
+
 ## Version 0.10.0 (2020-12-10)
 
 * Dependencies:

--- a/decaylanguage/_version.py
+++ b/decaylanguage/_version.py
@@ -5,7 +5,7 @@
 # or https://github.com/scikit-hep/decaylanguage for details.
 
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 
 version = __version__
 version_info = __version__.split(".")

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - pydot>=1.3.0
   - pip:
     - hepunits>=2.0.0
-    - particle==0.13.*
+    - particle==0.14.*
     - lark-parser>=0.8.0,<0.8.6
     - plumbum>=1.6.9
     - RISE


### PR DESCRIPTION
Trivial patch release to fix things for Conda, see failure at https://github.com/conda-forge/decaylanguage-feedstock/pull/3.