### PR TITLE
DecayChain - minor fix, more tests and doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Version 0.11 (UNDER DEVELOPMENT)
 
 * Universal representation of decay chains:
+  - More documentation and testing.
+  - Allow default class method `DecayMode.from_pdgids()` mimicking the default constructor `DecayMode()`.
+  - Fix in logic of ``DecayChain.flatten()``.
   - `DecayChainViewer` class adapted to make use of ``graphviz``.
 * Dependencies:
   - Got rid of dependency on ``pydot``, as the package is no longer maintained.

--- a/tests/decay/test_decay.py
+++ b/tests/decay/test_decay.py
@@ -71,16 +71,6 @@ def test_DecayMode_constructor_simple():
     assert dm.metadata == dict(model="", model_params="")
 
 
-def test_DecayMode_constructor_from_pdgids():
-    dm = DecayMode.from_pdgids(
-        0.5,
-        [321, -321],
-        model="TAUHADNU",
-        model_params=[-0.108, 0.775, 0.149, 1.364, 0.400],
-    )
-    assert dm.daughters == DaughtersDict("K+ K-")
-
-
 def test_DecayMode_constructor_with_model_info():
     dd = DaughtersDict("pi- pi0 nu_tau")
     dm = DecayMode(
@@ -92,7 +82,7 @@ def test_DecayMode_constructor_with_model_info():
     }
 
 
-def test_DecayMode_constructor_with_user_model_info():
+def test_DecayMode_constructor_with_user_metadata():
     dd = DaughtersDict("K+ K-")
     dm = DecayMode(0.5, dd, model="PHSP", study="toy", year=2019)
     assert dm.metadata == {
@@ -101,6 +91,23 @@ def test_DecayMode_constructor_with_user_model_info():
         "study": "toy",
         "year": 2019,
     }
+
+
+def test_DecayMode_constructor_from_pdgids_default():
+    dm = DecayMode.from_pdgids()
+    assert dm.bf == 0
+    assert dm.daughters == DaughtersDict()
+    assert dm.metadata == dict(model="", model_params="")
+
+
+def test_DecayMode_constructor_from_pdgids():
+    dm = DecayMode.from_pdgids(
+        0.5,
+        [321, -321],
+        model="TAUHADNU",
+        model_params=[-0.108, 0.775, 0.149, 1.364, 0.400],
+    )
+    assert dm.daughters == DaughtersDict("K+ K-")
 
 
 def test_DecayMode_constructor_from_dict():
@@ -119,7 +126,7 @@ def test_DecayMode_describe_simple():
     assert "Decay model: TAUHADNU [-0.108, 0.775, 0.149, 1.364, 0.4]" in dm.describe()
 
 
-def test_DecayMode_describe_with_extra_info():
+def test_DecayMode_describe_with_user_metadata():
     dd = DaughtersDict("K+ K-")
     dm = DecayMode(1.0e-6, dd, model="PHSP", study="toy", year=2019)
     assert "Extra info:" in dm.describe()
@@ -258,9 +265,10 @@ def test_DecayChain_properties():
 
 
 def test_DecayChain_flatten():
-    dc_flatten = dc2.flatten()
-    assert dc_flatten.mother == dc2.mother
-    assert dc_flatten.bf == dc_flatten.visible_bf
+    dc2_flatten = dc2.flatten()
+    assert dc2_flatten.mother == dc2.mother
+    assert dc2_flatten.bf == dc2_flatten.visible_bf
+    assert dc2_flatten.decays[dc2.mother].daughters == DaughtersDict(['gamma', 'gamma', 'pi+', 'pi+','pi-'])
 
 
 def test_DecayChain_string_repr():


### PR DESCRIPTION
For the record: the issue with `DecayChain.flatten()` is subtle in the sense that
```
dm1 = DecayMode(0.6770, "D0 pi+")
dm2 = DecayMode(0.0124, "K_S0 pi0")
dm3 = DecayMode(0.692, "pi+ pi-")
dm4 = DecayMode(0.98823, "gamma gamma")
dc = DecayChain("D*+", {"D*+": dm1, "D0": dm2, "K_S0": dm3, "pi0": dm4})
dc.flatten()
```
would result in the correct final state "gamma gamma pi+ pi+ pi-" but then if one closely looks at the daughters of that flattened decay mode one would see that `dc.flatten().decays[dc.mother].daughters == DaughtersDict(['gamma', 'gamma', 'pi+', 'pi+','pi-'])` would evaluate to `False`! That's because keys in the `Counter` instance (i.e. `DaughtersDict`) remained present with a count of 0. That's OK in general but makes no sense for a decay final state. The fix makes sure counts of 0 get removed.

The same "clean-up" is implemented for the constructor in this PR.