### PR TITLE
feat: drop Python 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install package
       run: python -m pip install -e .[test]
 
-    - name: PyTest
+    - name: Pytest
       if: runner.os == 'Linux'
       run: python -m pip install pytest-github-actions-annotate-failures
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['2.7', '3.5', '3.7', '3.9', '3.10-dev']
+        python-version: ['3.6', '3.7', '3.8', '3.10']
         include:
-          - {os: macos-latest, python-version: '2.7'}
           - {os: macos-latest, python-version: '3.9'}
           - {os: windows-latest, python-version: '3.7'}
           - {os: windows-latest, python-version: '3.9'}
@@ -41,5 +40,5 @@ jobs:
       run: python -m pytest ./tests --doctest-modules --cov=src/decaylanguage --cov-report=xml
 
     - name: Test coverage with Codecov
-      if: "runner.os != 'Windows' && matrix.python-version != 3.5 && matrix.python-version != 3.7"
+      if: "runner.os != 'Windows' && matrix.python-version != 3.7"
       uses: codecov/codecov-action@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,18 @@
+ci:
+  autoupdate_commit_msg: "chore: update pre-commit hooks"
+  autofix_commit_msg: "style: pre-commit fixes"
 
 repos:
 - repo: https://github.com/asottile/pyupgrade
   rev: v2.29.0
   hooks:
   - id: pyupgrade
+    args: [--py36-plus]
 
 - repo: https://github.com/psf/black
   rev: 21.9b0
   hooks:
-  - id: black
+  - id: black-jupyter
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.0.1
@@ -24,7 +28,6 @@ repos:
   - id: requirements-txt-fixer
   - id: debug-statements
   - id: end-of-file-fixer
-  - id: fix-encoding-pragma
 
 - repo: https://github.com/PyCQA/isort
   rev: 5.9.3
@@ -35,7 +38,6 @@ repos:
   rev: v1.18.0
   hooks:
   - id: setup-cfg-fmt
-    args: [--min-py3-version=3.5, --max-py-version=3.10]
 
 - repo: https://github.com/mgedmin/check-manifest
   rev: "0.47"
@@ -56,3 +58,18 @@ repos:
   hooks:
   - id: flake8
     additional_dependencies: [flake8-bugbear]
+
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.1.0
+  hooks:
+  - id: codespell
+    args: ["-L", "hist,nd,circularly,ba"]
+    exclude: ^(notebooks/xarray.ipynb|notebooks/BoostHistogramHandsOn.ipynb)$
+
+- repo: local
+  hooks:
+  - id: disallow-caps
+    name: Disallow improper capitalization
+    language: pygrep
+    entry: PyBind|Numpy|Cmake|CCache|Github|PyTest
+    exclude: .pre-commit-config.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 
 repos:
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.28.0
+  rev: v2.29.0
   hooks:
   - id: pyupgrade
 
@@ -32,7 +32,7 @@ repos:
   - id: isort
 
 - repo: https://github.com/asottile/setup-cfg-fmt
-  rev: v1.17.0
+  rev: v1.18.0
   hooks:
   - id: setup-cfg-fmt
     args: [--min-py3-version=3.5, --max-py-version=3.10]
@@ -44,7 +44,7 @@ repos:
     stages: [manual]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.910
+  rev: v0.910-1
   hooks:
   - id: mypy
     files: src

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,8 +63,8 @@ repos:
   rev: v2.1.0
   hooks:
   - id: codespell
-    args: ["-L", "hist,nd,circularly,ba"]
-    exclude: ^(notebooks/xarray.ipynb|notebooks/BoostHistogramHandsOn.ipynb)$
+    args: ["-L", "vertexes,unkown,te"]
+    exclude: '^(.*\.DEC|notebooks/ExampleDecFileParsingWithLark\.ipynb)$'
 
 - repo: local
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
   - id: mypy
     files: src
     args: [--scripts-are-modules]
-    additional_dependencies: [attrs, types-six, particle, importlib_resources, numpy, types-deprecated]
+    additional_dependencies: [attrs, particle, importlib_resources, numpy, types-deprecated]
 
 - repo: https://github.com/PyCQA/flake8
   rev: 3.9.2

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Required and compatibility dependencies will be automatically installed by pip.
 ### Required dependencies:
 
 -   [particle](https://github.com/scikit-hep/particle): PDG particle data and identification codes
--   [Numpy](https://scipy.org/install.html): The numerical library for Python
+-   [NumPy](https://scipy.org/install.html): The numerical library for Python
 -   [pandas](https://pandas.pydata.org/): Tabular data in Python
 -   [attrs](https://github.com/python-attrs/attrs): DataClasses for Python
 -   [plumbum](https://github.com/tomerfiliba/plumbum): Command line tools
@@ -52,9 +52,6 @@ Required and compatibility dependencies will be automatically installed by pip.
     descriptions and visualizations of decay chains.
 
 ### Python compatibility:
--   [six](https://github.com/benjaminp/six): Compatibility library
--   [pathlib2](https://github.com/mcmtroffaes/pathlib2) backport if using Python 2.7
--   [enum34](https://bitbucket.org/stoneleaf/enum34) backport if using Python /< 3.5
 -   [importlib_resources](http://importlib-resources.readthedocs.io/en/latest/) backport if using Python /< 3.7
 </p></details>
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ pip install decaylanguage
 ```
 
 You can use a virtual environment through pipenv or with `--user` if you know
-what those are. [Python 2.7 and 3.4+](http://docs.python-guide.org/en/latest/starting/installation) are supported.
+what those are. [Python
+3.6+](http://docs.python-guide.org/en/latest/starting/installation) supported
+(see version 0.12 for Python 2 & 3.5 support).
 
 <details><summary>Dependencies: (click to expand)</summary><p>
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import os
 
 extensions = [
@@ -24,7 +21,7 @@ master_doc = "index"
 project = "decaylanguage"
 year = "2018"
 author = "Henry Fredrick Schreiner III"
-copyright = "{}, {}".format(year, author)
+copyright = f"{year}, {author}"
 version = release = "0.2.0"
 
 pygments_style = "trac"
@@ -45,7 +42,7 @@ html_split_index = False
 html_sidebars = {
     "**": ["searchbox.html", "globaltoc.html", "sourcelink.html"],
 }
-html_short_title = "{}-{}".format(project, version)
+html_short_title = f"{project}-{version}"
 
 napoleon_use_ivar = True
 napoleon_use_rtype = False

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,6 @@ dependencies:
   - attrs>=19.2
   - pip>=9
   - jupyterlab>=0.35
-  - six>=1.11
   - numpy>=1.12
   - graphviz
   - plumbum>=1.6.9

--- a/notebooks/AmpGen2GooFit D2K3p.ipynb
+++ b/notebooks/AmpGen2GooFit D2K3p.ipynb
@@ -55,6 +55,7 @@
    "outputs": [],
    "source": [
     "from plumbum import colors\n",
+    "\n",
     "colors.use_color = 2"
    ]
   },
@@ -66,7 +67,7 @@
    },
    "outputs": [],
    "source": [
-    "lines, all_states = GooFitChain.read_ampgen('../models/DtoKpipipi_v2.txt')"
+    "lines, all_states = GooFitChain.read_ampgen(\"../models/DtoKpipipi_v2.txt\")"
    ]
   },
   {
@@ -259,10 +260,10 @@
    ],
    "source": [
     "for seen_factor in {p.spindetails() for p in lines}:\n",
-    "    my_lines = [p for p in lines if p.spindetails()==seen_factor]\n",
+    "    my_lines = [p for p in lines if p.spindetails() == seen_factor]\n",
     "    print(colors.bold | seen_factor, \":\", *my_lines[0].spinfactors)\n",
     "    for line in my_lines:\n",
-    "        colors.blue.print(' ', line)"
+    "        colors.blue.print(\" \", line)"
    ]
   },
   {
@@ -286,7 +287,11 @@
    ],
    "source": [
     "for spintype, c in zip(SpinType, colors):\n",
-    "    ps = [c | format(str(p), '11') for p in GooFitChain.all_particles if p.spin_type == spintype]\n",
+    "    ps = [\n",
+    "        c | format(str(p), \"11\")\n",
+    "        for p in GooFitChain.all_particles\n",
+    "        if p.spin_type == spintype\n",
+    "    ]\n",
     "    print(c & colors.bold | \"{:>12}:\".format(spintype.name), *ps)"
    ]
   },
@@ -337,9 +342,14 @@
    ],
    "source": [
     "for n, line in enumerate(lines):\n",
-    "    print(colors.bold | '{:2}'.format(n), '{:<70}'.format(str(line)),\n",
-    "          colors.bold & colors.blue | 'spinfactors:', colors.blue | str(len(line.spinfactors)),\n",
-    "          colors.bold & colors.magenta | 'L:', colors.magenta | '{0} [{1[0]}-{1[1]}]'.format(line.L, line.L_range()))"
+    "    print(\n",
+    "        colors.bold | \"{:2}\".format(n),\n",
+    "        \"{:<70}\".format(str(line)),\n",
+    "        colors.bold & colors.blue | \"spinfactors:\",\n",
+    "        colors.blue | str(len(line.spinfactors)),\n",
+    "        colors.bold & colors.magenta | \"L:\",\n",
+    "        colors.magenta | \"{0} [{1[0]}-{1[1]}]\".format(line.L, line.L_range()),\n",
+    "    )"
    ]
   },
   {
@@ -378,7 +388,7 @@
     }
    ],
    "source": [
-    "colors.bold.print('All discovered spin configurations:')\n",
+    "colors.bold.print(\"All discovered spin configurations:\")\n",
     "\n",
     "for line in sorted({line.spindetails() for line in lines}):\n",
     "    print(line)"
@@ -414,7 +424,7 @@
     }
    ],
    "source": [
-    "colors.bold.print('All known spin configurations:')\n",
+    "colors.bold.print(\"All known spin configurations:\")\n",
     "\n",
     "for e in SF_4Body:\n",
     "    print(e.name)"
@@ -844,7 +854,7 @@
     }
    ],
    "source": [
-    "colors.green.print('    // Parameters')\n",
+    "colors.green.print(\"    // Parameters\")\n",
     "print(GooFitChain.make_pars())"
    ]
   },
@@ -1901,10 +1911,10 @@
     }
    ],
    "source": [
-    "colors.green.print('    // Lines')\n",
+    "colors.green.print(\"    // Lines\")\n",
     "for n, line in enumerate(lines):\n",
-    "    colors.green.print('    // Line', n)\n",
-    "    print(line.to_goofit(all_states[1:]), end='\\n\\n\\n')"
+    "    colors.green.print(\"    // Line\", n)\n",
+    "    print(line.to_goofit(all_states[1:]), end=\"\\n\\n\\n\")"
    ]
   },
   {

--- a/notebooks/DecayLanguageDemo.ipynb
+++ b/notebooks/DecayLanguageDemo.ipynb
@@ -69,7 +69,7 @@
     }
    ],
    "source": [
-    "with open('simple_model.txt') as f:\n",
+    "with open(\"simple_model.txt\") as f:\n",
     "    print(f.read())"
    ]
   },
@@ -315,7 +315,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lines, all_states = GooFitChain.read_ampgen('simple_model.txt')"
+    "lines, all_states = GooFitChain.read_ampgen(\"simple_model.txt\")"
    ]
   },
   {
@@ -513,7 +513,7 @@
     }
    ],
    "source": [
-    "with open('../tests/data/test_example_Dst.dec') as f:\n",
+    "with open(\"../tests/data/test_example_Dst.dec\") as f:\n",
     "    print(f.read())"
    ]
   },
@@ -538,7 +538,7 @@
     }
    ],
    "source": [
-    "parser = DecFileParser('../tests/data/test_example_Dst.dec')\n",
+    "parser = DecFileParser(\"../tests/data/test_example_Dst.dec\")\n",
     "parser"
    ]
   },
@@ -583,7 +583,7 @@
     }
    ],
    "source": [
-    "parser.print_decay_modes('D*+')"
+    "parser.print_decay_modes(\"D*+\")"
    ]
   },
   {
@@ -623,7 +623,7 @@
     }
    ],
    "source": [
-    "parser.list_decay_modes('D*+')"
+    "parser.list_decay_modes(\"D*+\")"
    ]
   },
   {
@@ -690,7 +690,7 @@
     }
    ],
    "source": [
-    "d = parser.build_decay_chains('D+')\n",
+    "d = parser.build_decay_chains(\"D+\")\n",
     "d"
    ]
   },
@@ -1209,7 +1209,7 @@
     }
    ],
    "source": [
-    "d = parser.build_decay_chains('D*+')\n",
+    "d = parser.build_decay_chains(\"D*+\")\n",
     "DecayChainViewer(d)"
    ]
   },
@@ -1399,7 +1399,7 @@
     }
    ],
    "source": [
-    "d = parser.build_decay_chains('D*+', stable_particles=['D+'])\n",
+    "d = parser.build_decay_chains(\"D*+\", stable_particles=[\"D+\"])\n",
     "DecayChainViewer(d)"
    ]
   },
@@ -1598,7 +1598,7 @@
     }
    ],
    "source": [
-    "d = parser.build_decay_chains('D*-')\n",
+    "d = parser.build_decay_chains(\"D*-\")\n",
     "DecayChainViewer(d)"
    ]
   },
@@ -1632,7 +1632,7 @@
     }
    ],
    "source": [
-    "parser = DecFileParser('../src/decaylanguage/data/DECAY_LHCB.DEC')\n",
+    "parser = DecFileParser(\"../src/decaylanguage/data/DECAY_LHCB.DEC\")\n",
     "parser"
    ]
   },

--- a/notebooks/DecayLanguageDemo.ipynb
+++ b/notebooks/DecayLanguageDemo.ipynb
@@ -31,7 +31,7 @@
     "        * GooFit C++\n",
     "* **Decay file parsers**:\n",
     "    - Read DecFiles, such as the LHCb master DecFile\n",
-    "    - Manipulate adn visualize them in Python"
+    "    - Manipulate and visualize them in Python"
    ]
   },
   {

--- a/notebooks/ExampleDecFileParsingWithLark.ipynb
+++ b/notebooks/ExampleDecFileParsingWithLark.ipynb
@@ -101,7 +101,7 @@
       "// model : model_generic\n",
       "// model_helamp : \"HELAMP\" (SIGNED_NUMBER SIGNED_NUMBER)+\n",
       "\n",
-      "// Terminal defintions\n",
+      "// Terminal definitions\n",
       "// To use a fast parser, we need to avoid conflicts\n",
       "\n",
       "%import common.WS_INLINE\n",

--- a/notebooks/ExampleDecFileParsingWithLark.ipynb
+++ b/notebooks/ExampleDecFileParsingWithLark.ipynb
@@ -29,10 +29,10 @@
    "cell_type": "code",
    "execution_count": 2,
    "source": [
-    "with data.basepath.joinpath('decfile.lark').open() as f:\n",
+    "with data.basepath.joinpath(\"decfile.lark\").open() as f:\n",
     "    grammar = f.read()\n",
     "\n",
-    "with open('../tests/data/test_example_Dst.dec') as f:\n",
+    "with open(\"../tests/data/test_example_Dst.dec\") as f:\n",
     "    dec_file = f.read()"
    ],
    "outputs": [],
@@ -193,7 +193,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "source": [
-    "l = Lark(grammar, parser='lalr', lexer='standard')\n",
+    "l = Lark(grammar, parser=\"lalr\", lexer=\"standard\")\n",
     "parsed_dec_file = l.parse(dec_file)"
    ],
    "outputs": [],
@@ -205,9 +205,10 @@
    "source": [
     "def number_of_decays(parsed_file):\n",
     "    \"\"\"Returns the number of particle decays defined in the parsed .dec file.\"\"\"\n",
-    "    return len(list(parsed_file.find_data('decay')))\n",
+    "    return len(list(parsed_file.find_data(\"decay\")))\n",
     "\n",
-    "print('# of decays in file =',  number_of_decays(parsed_dec_file))"
+    "\n",
+    "print(\"# of decays in file =\", number_of_decays(parsed_dec_file))"
    ],
    "outputs": [
     {
@@ -226,8 +227,9 @@
    "source": [
     "def list_of_decay_trees(parsed_file):\n",
     "    \"\"\"Return a list of the actual decays defined in the .dec file.\"\"\"\n",
-    "    list_of_decays = list(parsed_file.find_data('decay'))\n",
+    "    list_of_decays = list(parsed_file.find_data(\"decay\"))\n",
     "    return list_of_decays\n",
+    "\n",
     "\n",
     "list_of_decay_trees(parsed_dec_file)"
    ],
@@ -255,10 +257,24 @@
    "source": [
     "def get_decay_mode_details(decay_mode_Tree):\n",
     "    \"\"\"Parse a decay mode tree and return the relevant bits of information in it.\"\"\"\n",
-    "    bf = [x for x in decay_mode_Tree.find_data('value')][0].children[0].value if len([x for x in decay_mode_Tree.find_data('value')])==1 else None\n",
+    "    bf = (\n",
+    "        [x for x in decay_mode_Tree.find_data(\"value\")][0].children[0].value\n",
+    "        if len([x for x in decay_mode_Tree.find_data(\"value\")]) == 1\n",
+    "        else None\n",
+    "    )\n",
     "    bf = float(bf)\n",
-    "    products = tuple([p.children[0].value for p in decay_mode_Tree.children if isinstance(p,Tree) and p.data=='particle'])\n",
-    "    model = [x for x in decay_mode_Tree.find_data('model')][0].children[0].value if len([x for x in decay_mode_Tree.find_data('model')])==1 else None\n",
+    "    products = tuple(\n",
+    "        [\n",
+    "            p.children[0].value\n",
+    "            for p in decay_mode_Tree.children\n",
+    "            if isinstance(p, Tree) and p.data == \"particle\"\n",
+    "        ]\n",
+    "    )\n",
+    "    model = (\n",
+    "        [x for x in decay_mode_Tree.find_data(\"model\")][0].children[0].value\n",
+    "        if len([x for x in decay_mode_Tree.find_data(\"model\")]) == 1\n",
+    "        else None\n",
+    "    )\n",
     "    return (bf, products, model)"
    ],
    "outputs": [],
@@ -278,12 +294,17 @@
     "decays = {}\n",
     "\n",
     "for tree in list_of_decay_trees(parsed_dec_file):\n",
-    "    if tree.data == 'decay':\n",
+    "    if tree.data == \"decay\":\n",
     "        if tree.children[0].children[0].value in decays:\n",
-    "            print('Decays of particle %s are redefined! Please check your .dec file.' % tree.children[0].children[0].value)\n",
+    "            print(\n",
+    "                \"Decays of particle %s are redefined! Please check your .dec file.\"\n",
+    "                % tree.children[0].children[0].value\n",
+    "            )\n",
     "        decays[tree.children[0].children[0].value] = []\n",
-    "        for decay_mode in tree.find_data('decayline'):\n",
-    "            decays[tree.children[0].children[0].value].append(get_decay_mode_details(decay_mode))"
+    "        for decay_mode in tree.find_data(\"decayline\"):\n",
+    "            decays[tree.children[0].children[0].value].append(\n",
+    "                get_decay_mode_details(decay_mode)\n",
+    "            )"
    ],
    "outputs": [],
    "metadata": {}
@@ -303,7 +324,7 @@
     "    \"\"\"Pretty print of the decay modes of a given particle.\"\"\"\n",
     "    print(dec)\n",
     "    for fs in final_state:\n",
-    "        print('%12g : %50s %15s' % (fs[0], '  '.join(p for p in fs[1]), fs[2]))"
+    "        print(\"%12g : %50s %15s\" % (fs[0], \"  \".join(p for p in fs[1]), fs[2]))"
    ],
    "outputs": [],
    "metadata": {}
@@ -312,7 +333,7 @@
    "cell_type": "code",
    "execution_count": 11,
    "source": [
-    "print_decay('pi0', decays['pi0'])"
+    "print_decay(\"pi0\", decays[\"pi0\"])"
    ],
    "outputs": [
     {
@@ -378,9 +399,12 @@
    "source": [
     "from lark.tree import pydot__tree_to_png  # requires pydot\n",
     "\n",
-    "pydot__tree_to_png(list_of_decay_trees(parsed_dec_file)[0], filename='decay.png', rankdir=\"LR\")\n",
+    "pydot__tree_to_png(\n",
+    "    list_of_decay_trees(parsed_dec_file)[0], filename=\"decay.png\", rankdir=\"LR\"\n",
+    ")\n",
     "\n",
     "from IPython.display import Image\n",
+    "\n",
     "Image(filename=\"decay.png\")"
    ],
    "outputs": [

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,6 @@
 import nox
 
-PYTHON_VERSIONS = ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
+PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import nox
 
 PYTHON_VERSIONS = ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,5 +30,11 @@ module = [
 ignore_missing_imports = true
 
 
-# pytest config cannot be moved here until Python 2 support is dropped and
-# pytest 6+ can be required.
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = [
+   "-ra",
+   "--doctest-modules",
+   '--doctest-glob=\*.rst',
+]
+log_cli_level = "DEBUG"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,5 +30,5 @@ module = [
 ignore_missing_imports = true
 
 
-# PyTest config cannot be moved here until Python 2 support is dropped and
-# PyTest 6+ can be required.
+# pytest config cannot be moved here until Python 2 support is dropped and
+# pytest 6+ can be required.

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,6 @@ install_requires =
     pandas>=0.22
     particle==0.16.*
     plumbum>=1.6.9
-    six>=1.11
     cachetools;python_version<"3.3"
     enum34>=1.1;python_version<"3.4"
     importlib_resources>=2.0;python_version<"3.9"

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,13 +60,6 @@ test =
     pytest>=6
     pytest-cov
 
-[tool:pytest]
-testpaths = tests
-addopts =
-    -ra
-    --doctest-modules
-    --doctest-glob=\*.rst
-
 [flake8]
 max-complexity = 24
 ignore = E203, E231, E501, E722, W503, B950

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,9 +18,8 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -45,11 +44,8 @@ install_requires =
     pandas>=0.22
     particle==0.16.*
     plumbum>=1.6.9
-    cachetools;python_version<"3.3"
-    enum34>=1.1;python_version<"3.4"
     importlib_resources>=2.0;python_version<"3.9"
-    pathlib2>=2.3;python_version<"3.5"
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*
+python_requires = >=3.6
 include_package_data = True
 package_dir =
     =src
@@ -59,13 +55,10 @@ where = src
 
 [options.extras_require]
 dev =
-    pytest>=4.6
+    pytest>=6
 test =
-    pytest>=4.6
+    pytest>=6
     pytest-cov
-
-[bdist_wheel]
-universal = 1
 
 [tool:pytest]
 testpaths = tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -51,7 +50,7 @@ install_requires =
     enum34>=1.1;python_version<"3.4"
     importlib_resources>=2.0;python_version<"3.9"
     pathlib2>=2.3;python_version<"3.5"
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
+python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*
 include_package_data = True
 package_dir =
     =src

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE

--- a/src/decaylanguage/__init__.py
+++ b/src/decaylanguage/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE

--- a/src/decaylanguage/__main__.py
+++ b/src/decaylanguage/__main__.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/decaylanguage for details.
 
-from __future__ import absolute_import, division, print_function
 
 from plumbum import cli
 

--- a/src/decaylanguage/data/WorkingOutModel.ipynb
+++ b/src/decaylanguage/data/WorkingOutModel.ipynb
@@ -3,16 +3,15 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "with open(\"DECAY_CLASSIC.DEC\") as f:\n",
     "    txt = f.readlines()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Useful resources:\n",
     "* https://tomassetti.me/parsing-in-python/\n",
@@ -20,16 +19,28 @@
     "* https://github.com/lark-parser/lark/blob/9f666a74595ff8ac0f550abbb687a517fe5d495d/lark/grammars/common.lark\n",
     "* https://gitlab.cern.ch/lhcb-datapkg/Gen/DecFiles/tree/master/dkfiles\n",
     "* https://github.com/PMunkes/evtgen/blob/master/DECAY.DEC\n"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 90,
-   "metadata": {},
+   "source": [
+    "seen = set()\n",
+    "testlines = \"\"\n",
+    "for i, t in enumerate(txt[:222]):\n",
+    "    t = t.strip()\n",
+    "    if t and t[0] != \"#\":\n",
+    "        start = t.split()[0]\n",
+    "        if not start in seen:\n",
+    "            print(i, t)\n",
+    "            seen.add(start)\n",
+    "            testlines += t + \"\\n\""
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "4 Define qoverp_incohMix_B_s0 1.0\n",
       "51 Alias K*L       K*0\n",
@@ -56,24 +67,11 @@
      ]
     }
    ],
-   "source": [
-    "seen = set()\n",
-    "testlines = \"\"\n",
-    "for i, t in enumerate(txt[:222]):\n",
-    "    t = t.strip()\n",
-    "    if t and t[0] != \"#\":\n",
-    "        start = t.split()[0]\n",
-    "        if not start in seen:\n",
-    "            print(i, t)\n",
-    "            seen.add(start)\n",
-    "            testlines += t + \"\\n\""
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 145,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "examples = set()\n",
     "models = set()\n",
@@ -101,14 +99,19 @@
     "        ]\n",
     "        examples.add(\" \".join(ts))\n",
     "        models.add(ts[0])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 146,
-   "metadata": {},
+   "source": [
+    "examples"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "{'BTO3PI_CP dm alpha',\n",
@@ -155,47 +158,49 @@
        " 'VVS_PWAVE number number number number number number'}"
       ]
      },
-     "execution_count": 146,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 146
     }
    ],
-   "source": [
-    "examples"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 217,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "from lark import Lark"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 218,
-   "metadata": {},
+   "source": [
+    "for m in sorted(models):\n",
+    "    print(f'\"{m}\"', end=\"|\")"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "\"BTO3PI_CP\"|\"BTOSLLALI\"|\"BTOSLLBALL\"|\"BTOXSGAMMA\"|\"BTOXSLL\"|\"CB3PI-MPP\"|\"CB3PI-P00\"|\"D_DALITZ\"|\"ETA_DALITZ\"|\"GOITY_ROBERTS\"|\"HELAMP\"|\"HQET\"|\"ISGW2\"|\"OMEGA_DALITZ\"|\"PARTWAVE\"|\"PHSP\"|\"PI0_DALITZ\"|\"PYTHIA\"|\"SLN\"|\"STS\"|\"SVP_HELAMP\"|\"SVS\"|\"SVV_HELAMP\"|\"TAUHADNU\"|\"TAULNUNU\"|\"TAUSCALARNU\"|\"TAUVECTORNU\"|\"TSS\"|\"TVS_PWAVE\"|\"VLL\"|\"VSP_PWAVE\"|\"VSS\"|\"VSS_BMIX\"|\"VUB\"|\"VVP\"|\"VVPIPI\"|\"VVS_PWAVE\"|"
      ]
     }
    ],
-   "source": [
-    "for m in sorted(models):\n",
-    "    print(f'\"{m}\"', end=\"|\")"
-   ]
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 528,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "l = Lark(\n",
     "    r\"\"\"\n",
@@ -235,7 +240,7 @@
     "// model_helamp : \"HELAMP\" (SIGNED_NUMBER SIGNED_NUMBER)+\n",
     "\n",
     "\n",
-    "// Terminal defintions\n",
+    "// Terminal definitions\n",
     "// To use a fast parser, we need to avoid conflicts\n",
     "\n",
     "%import common.WS_INLINE\n",
@@ -257,16 +262,23 @@
     "    parser=\"lalr\",\n",
     "    lexer=\"standard\",\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 529,
-   "metadata": {},
+   "source": [
+    "print(testlines)\n",
+    "\n",
+    "ll = l.parse(testlines)\n",
+    "print(ll.pretty())"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Define qoverp_incohMix_B_s0 1.0\n",
       "Alias K*L       K*0\n",
@@ -515,38 +527,38 @@
      ]
     }
    ],
-   "source": [
-    "print(testlines)\n",
-    "\n",
-    "ll = l.parse(testlines)\n",
-    "print(ll.pretty())"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 460,
-   "metadata": {},
+   "source": [
+    "print(*[i + 1 for i, t in enumerate(txt) if \"Enddecay\" in t])"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "193 222 1485 2702 3709 4711 4727 4730 4733 4736 4739 4742 5215 5662 5680 5697 5763 5773 5778 5782 5786 5791 5795 5942 6084 6088 6276 6281 6462 6563 6662 6669 6673 6677 6681 6696 6700 6704 6708 6713 6717 6721 6725 6742 6748 6754 6760 6768 6773 6779 6785 6789 6793 6799 6805 6813 6817 6821 6825 6831 6837 6843 6849 6865 6872 6876 6882 6888 6894 6900 6908 6911 6914 6917 6920 6923 6929 6934 6939 6943 6948 6952 6964 6976 6988 7000 7010 7020 7030 7040 7053 7066 7079 7092 7105 7114 7123 7132 7144 7153 7162 7171 7175 7179 7183 7187 7192 7196 7206 7218 7222 7225 7228 7242 7254 7278 7283 7287 7291 7301 7311 7323 7328 7332 7336 7343 7347 7351 7359 7369 7389 7396 7409 7421 7431 7437 7444 7450 7455 7461 7484 7507 7530 7553 7576 7599 7622 7645 7682 7690 7842 7940 7965 7993 8028 8086 8131 8183 8196 8200 8207 8231 8253 8278 8289 8297 8314 8332 8341 8364 8403 8407 8416 8427 8459 8472 8489 8497 8512 8531 8541 8545 8548 8551 8554 8661 8666 8669 8676 8681 8684 8688 8691 8711 8730 8734 8737 8743 8748 8752 8755 8766 8775 8781 8787 8802 8817 8825 8833 8842 8851 8865 8879 8892 8905 8918 8931 8947 8963 8974 8985 8994 9002 9010 9018 9029 9040 9047 9054 9060 9065 9069 9072 9077 9081 9087 9092 9096 9099 9107 9114 9119 9123 9129 9134 9140 9145 9151 9156 9165 9173 9181 9188 9193 9197 9206 9214 9219 9224 9229 9235 9241 9246 9252 9260 9265 9274 9351 9427 9457 9486 9520 9553 9574 9594 9599 9602 9606 9609 9613 9616 9727 9835 9849 9859 9865 9870 9877 9880 9884 9887 9892 9896 9901 9905 9910 9914 9925 9935 9940 9944 9949 9953 9958 9962 9973 9983 9988 9992 9997 10001 10006 10010 10017 10023 10027 10030 10037 10043 10047 10050 10054 10057 10061 10064 10068 10071 10075 10078 10082 10085 10090 10094 10099 10103 10108 10112 10122 10131 10140 10149 10158 10167 10176 10185 10194 10203 10212 10221 10246\n"
      ]
     }
    ],
-   "source": [
-    "print(*[i + 1 for i, t in enumerate(txt) if \"Enddecay\" in t])"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 461,
-   "metadata": {},
+   "source": [
+    "for n, line in enumerate(txt):\n",
+    "    q = line.split(\"#\")[0].strip()\n",
+    "    if q and \"SetLineshapePW\" in q:\n",
+    "        print(n, q)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "6683 SetLineshapePW D_1+ D*+ pi0 2\n",
       "6684 SetLineshapePW D_1+ D*0 pi+ 2\n",
@@ -567,21 +579,18 @@
      ]
     }
    ],
-   "source": [
-    "for n, line in enumerate(txt):\n",
-    "    q = line.split(\"#\")[0].strip()\n",
-    "    if q and \"SetLineshapePW\" in q:\n",
-    "        print(n, q)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 462,
-   "metadata": {},
+   "source": [
+    "print(\"\".join(txt[-5:]))"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "#0.000000007 mu+     mu-     gamma   gamma                   PHSP;  #[New mode added] #[Reconstructed PDG2011]\n",
       "Enddecay\n",
@@ -592,63 +601,61 @@
      ]
     }
    ],
-   "source": [
-    "print(\"\".join(txt[-5:]))"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 530,
-   "metadata": {},
+   "source": [
+    "%%time\n",
+    "parsed = l.parse(\"\".join(txt))\n",
+    "bool(parsed)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "CPU times: user 1.21 s, sys: 17.9 ms, total: 1.23 s\n",
       "Wall time: 1.25 s\n"
      ]
     }
    ],
-   "source": [
-    "%%time\n",
-    "parsed = l.parse(\"\".join(txt))\n",
-    "bool(parsed)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 531,
-   "metadata": {},
+   "source": [
+    "parsed.children[-1]"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "Tree(line, [Tree(decay, [Tree(particle, [Token(LABEL, 'K_L0')])])])"
       ]
      },
-     "execution_count": 531,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 531
     }
    ],
-   "source": [
-    "parsed.children[-1]"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "source": [],
    "outputs": [],
-   "source": []
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "source": [],
    "outputs": [],
-   "source": []
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/src/decaylanguage/data/WorkingOutModel.ipynb
+++ b/src/decaylanguage/data/WorkingOutModel.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open('DECAY_CLASSIC.DEC') as f:\n",
+    "with open(\"DECAY_CLASSIC.DEC\") as f:\n",
     "    txt = f.readlines()"
    ]
   },
@@ -80,15 +80,26 @@
     "for t in txt:\n",
     "    t = t.split(\"#\")[0]\n",
     "    t = t.strip()\n",
-    "    if ';' in t:\n",
-    "        ts = t.strip(';').split()\n",
+    "    if \";\" in t:\n",
+    "        ts = t.strip(\";\").split()\n",
     "        del ts[0]\n",
-    "        while ts[0].upper() != ts[0] or \"+\" in ts[0] or \"'\" in ts[0] or ts[0].endswith(\"-\") or \"*\" in ts[0] or ts[0].startswith(\"K_\") or ts[0] in (\"D0\", \"K0\", \"B0\", \"D_10\", \"D(2S)0\"):\n",
+    "        while (\n",
+    "            ts[0].upper() != ts[0]\n",
+    "            or \"+\" in ts[0]\n",
+    "            or \"'\" in ts[0]\n",
+    "            or ts[0].endswith(\"-\")\n",
+    "            or \"*\" in ts[0]\n",
+    "            or ts[0].startswith(\"K_\")\n",
+    "            or ts[0] in (\"D0\", \"K0\", \"B0\", \"D_10\", \"D(2S)0\")\n",
+    "        ):\n",
     "            del ts[0]\n",
     "        if ts[0] == \"PHOTOS\":\n",
     "            del ts[0]\n",
-    "        ts = ['number' if t.replace('.', '1', 1).lstrip('-').lstrip('+').isdigit() else t for t in ts ]\n",
-    "        examples.add(' '.join(ts))\n",
+    "        ts = [\n",
+    "            \"number\" if t.replace(\".\", \"1\", 1).lstrip(\"-\").lstrip(\"+\").isdigit() else t\n",
+    "            for t in ts\n",
+    "        ]\n",
+    "        examples.add(\" \".join(ts))\n",
     "        models.add(ts[0])"
    ]
   },
@@ -177,7 +188,7 @@
    ],
    "source": [
     "for m in sorted(models):\n",
-    "    print(f'\"{m}\"', end = \"|\")"
+    "    print(f'\"{m}\"', end=\"|\")"
    ]
   },
   {
@@ -186,7 +197,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "l = Lark(r'''\n",
+    "l = Lark(\n",
+    "    r\"\"\"\n",
     "start : (line | _NEWLINE)+ (_END _NEWLINE*)?\n",
     "line : (define | alias | chargeconj | commands | decay | cdecay | setlspw) _NEWLINE\n",
     "\n",
@@ -240,7 +252,11 @@
     "\n",
     "// Disregard spaces in text\n",
     "%ignore WS_INLINE\n",
-    "''' , debug=True, parser='lalr', lexer='standard')"
+    "\"\"\",\n",
+    "    debug=True,\n",
+    "    parser=\"lalr\",\n",
+    "    lexer=\"standard\",\n",
+    ")"
    ]
   },
   {
@@ -520,7 +536,7 @@
     }
    ],
    "source": [
-    "print(*[i+1 for i,t in enumerate(txt) if 'Enddecay' in t])"
+    "print(*[i + 1 for i, t in enumerate(txt) if \"Enddecay\" in t])"
    ]
   },
   {
@@ -554,7 +570,7 @@
    "source": [
     "for n, line in enumerate(txt):\n",
     "    q = line.split(\"#\")[0].strip()\n",
-    "    if q and 'SetLineshapePW' in q:\n",
+    "    if q and \"SetLineshapePW\" in q:\n",
     "        print(n, q)"
    ]
   },
@@ -577,7 +593,7 @@
     }
    ],
    "source": [
-    "print(''.join(txt[-5:]))"
+    "print(\"\".join(txt[-5:]))"
    ]
   },
   {
@@ -596,7 +612,7 @@
    ],
    "source": [
     "%%time\n",
-    "parsed = l.parse(''.join(txt))\n",
+    "parsed = l.parse(\"\".join(txt))\n",
     "bool(parsed)"
    ]
   },

--- a/src/decaylanguage/data/__init__.py
+++ b/src/decaylanguage/data/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import sys
 
 from deprecated import deprecated

--- a/src/decaylanguage/data/ampgen.lark
+++ b/src/decaylanguage/data/ampgen.lark
@@ -39,7 +39,7 @@ particle : LABEL
 
 subdecay : "{" decay "," decay "}"
 
-// Terminal defintions
+// Terminal definitions
 
 %import common.WS_INLINE
 %import common.SIGNED_NUMBER

--- a/src/decaylanguage/data/decfile.lark
+++ b/src/decaylanguage/data/decfile.lark
@@ -43,7 +43,7 @@ model_options : (value | LABEL | _NEWLINE)+
 // model : model_generic
 // model_helamp : "HELAMP" (SIGNED_NUMBER SIGNED_NUMBER)+
 
-// Terminal defintions
+// Terminal definitions
 // To use a fast parser, we need to avoid conflicts
 
 %import common.WS_INLINE

--- a/src/decaylanguage/dec/__init__.py
+++ b/src/decaylanguage/dec/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .dec import DecFileParser
 from .enums import known_decay_models
 

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -53,10 +53,6 @@ from .. import data
 from ..utils import charge_conjugate_name
 from .enums import PhotosEnum
 
-# New in Python 3
-if sys.version_info < (3,):
-    FileNotFoundError = IOError
-
 
 class DecFileNotParsed(RuntimeError):
     pass

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -1023,10 +1023,10 @@ def get_branching_fraction(decay_mode):
     # and tree.children[0].children[0].value is the BF stored as a str
     try:  # the branching fraction value as a float
         return float(decay_mode.children[0].children[0].value)
-    except RuntimeError:
+    except RuntimeError as e:
         raise RuntimeError(
             "'decayline' Tree does not seem to have the usual structure. Check it."
-        )
+        ) from e
 
 
 def get_final_state_particles(decay_mode):

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
@@ -37,24 +36,18 @@ Basic assumptions
     with another 'CopyDecay' statement.
 """
 
-from __future__ import absolute_import, division, print_function
 
 import operator
 import os
 import re
 import sys
 import warnings
-
-from six import StringIO
-
-if sys.version_info < (3,):
-    from itertools import izip_longest as zip_longest
-else:
-    from itertools import zip_longest
+from itertools import zip_longest
 
 from lark import Lark, Tree, Visitor
 from particle import Particle
 from particle.converters import PDG2EvtGenNameMap
+from six import StringIO
 
 from .. import data
 from ..utils import charge_conjugate_name
@@ -73,7 +66,7 @@ class DecayNotFound(RuntimeError):
     pass
 
 
-class DecFileParser(object):
+class DecFileParser:
     """
     The class to parse a .dec decay file.
 
@@ -114,9 +107,9 @@ class DecFileParser(object):
             for filename in self._dec_file_names:
                 # Check input file
                 if not os.path.exists(filename):
-                    raise FileNotFoundError("'{}'!".format(filename))
+                    raise FileNotFoundError(f"'{filename}'!")
 
-                with open(filename, "r") as file:
+                with open(filename) as file:
                     for line in file:
                         # We need to strip the unicode byte ordering if present before checking for *
                         beg = line.lstrip("\ufeff").lstrip()
@@ -739,7 +732,7 @@ All but the first occurrence will be discarded/removed ...""".format(
             if print_model:
                 line = "  {:.4f}   {}     {}  {}".format(bf / norm, *info)
             else:
-                line = "  {:.4f}   {}".format(bf / norm, info[0])
+                line = f"  {bf / norm:.4f}   {info[0]}"
             print(line.rstrip() + ";")
 
     @staticmethod
@@ -762,7 +755,7 @@ All but the first occurrence will be discarded/removed ...""".format(
             elif align_mode == "right":
                 return [s.rjust(max_len) for s in to_align]
             else:
-                raise ValueError("Unknown align mode: {}".format(align_mode))
+                raise ValueError(f"Unknown align mode: {align_mode}")
 
         aligned = []
         for cat in zip_longest(*to_align, fillvalue=""):
@@ -773,7 +766,7 @@ All but the first occurrence will be discarded/removed ...""".format(
             elif align_mode == "right":
                 row = [s.rjust(max_len) for s in cat]
             else:
-                raise ValueError("Unknown align mode: {}".format(align_mode))
+                raise ValueError(f"Unknown align mode: {align_mode}")
 
             aligned.append(row)
 

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -40,7 +40,6 @@ Basic assumptions
 import operator
 import os
 import re
-import sys
 import warnings
 from io import StringIO
 from itertools import zip_longest

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -42,12 +42,12 @@ import os
 import re
 import sys
 import warnings
+from io import StringIO
 from itertools import zip_longest
 
 from lark import Lark, Tree, Visitor
 from particle import Particle
 from particle.converters import PDG2EvtGenNameMap
-from six import StringIO
 
 from .. import data
 from ..utils import charge_conjugate_name

--- a/src/decaylanguage/dec/decparser.py
+++ b/src/decaylanguage/dec/decparser.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
-from __future__ import absolute_import, division, print_function
 
 import cmd
 import os
@@ -69,13 +67,13 @@ class DaughterList(dict):
         self[daughter] = self.get(daughter, 0)
 
 
-class AllowedDecays(object):
+class AllowedDecays:
     def __init__(self, particle):
         self.decay_of = particle
         self.decays = []
 
 
-class Decay(object):
+class Decay:
     def __init__(self, bf=0, daughters=None):
         if daughters is None:
             daughters = DaughterList()
@@ -252,7 +250,7 @@ class interactive(cmd.Cmd):
     def do_readfile(self, line):
         "Read a file in (defaults to the one built into this package)"
         fname = defdecfile if line == "" else line
-        with open(fname, "r") as infile:
+        with open(fname) as infile:
             q = decparser(stdin=infile)
             q.use_rawinput = False
             q.cmdloop()

--- a/src/decaylanguage/dec/decparser.py
+++ b/src/decaylanguage/dec/decparser.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-
+#!/usr/bin/env python3
 
 import cmd
 import os

--- a/src/decaylanguage/dec/decparser.py
+++ b/src/decaylanguage/dec/decparser.py
@@ -192,8 +192,8 @@ class decparser(cmd.Cmd):
         spl = line.split()
         try:
             bf = float(spl[0])
-        except Exception:
-            raise RuntimeError("Cannot parse decay line: %s" % line)
+        except Exception as e:
+            raise RuntimeError("Cannot parse decay line: %s" % line) from e
         #        mod_found = False
         #         for x in known_models:
         #             if x in line:

--- a/src/decaylanguage/dec/enums.py
+++ b/src/decaylanguage/dec/enums.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE

--- a/src/decaylanguage/decay/__init__.py
+++ b/src/decaylanguage/decay/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .decay import DaughtersDict, DecayChain, DecayMode
 from .viewer import DecayChainViewer
 

--- a/src/decaylanguage/decay/decay.py
+++ b/src/decaylanguage/decay/decay.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/decaylanguage for details.
 
-from __future__ import absolute_import, print_function
 
 from collections import Counter
 from copy import deepcopy
@@ -59,7 +57,7 @@ class DaughtersDict(Counter):
             iterable = {k: v for k, v in iterable.items() if v > 0}
         elif iterable and isinstance(iterable, str):
             iterable = iterable.split()
-        super(DaughtersDict, self).__init__(iterable, **kwds)
+        super().__init__(iterable, **kwds)
 
     def to_string(self):
         """
@@ -123,14 +121,14 @@ class DaughtersDict(Counter):
         """
         Add two final states, particle-type-wise.
         """
-        dd = super(DaughtersDict, self).__add__(other)
+        dd = super().__add__(other)
         return self.__class__(dd)
 
     def __iter__(self):
         return self.elements()
 
 
-class DecayMode(object):
+class DecayMode:
     """
     Class holding a particle decay mode, which is typically a branching fraction
     and a list of final-state particles (i.e. a list of DaughtersDict instances).
@@ -296,7 +294,7 @@ class DecayMode(object):
         if keys:
             val += "\n    Extra info:\n"
         for key in keys:
-            val += "        {k}: {v}\n".format(k=key, v=self.metadata[key])
+            val += f"        {key}: {self.metadata[key]}\n"
 
         return val
 
@@ -368,7 +366,7 @@ class DecayMode(object):
         return repr(self)
 
 
-class DecayChain(object):
+class DecayChain:
     """
     Class holding a particle decay chain, which is typically a top-level decay
     (mother particle, branching fraction and final-state particles)

--- a/src/decaylanguage/decay/decay.py
+++ b/src/decaylanguage/decay/decay.py
@@ -227,8 +227,8 @@ class DecayMode:
         try:
             bf = dm.pop("bf")
             daughters = dm.pop("fs")
-        except Exception:
-            raise RuntimeError("Input not in the expected format!")
+        except Exception as e:
+            raise RuntimeError("Input not in the expected format!") from e
 
         return cls(bf=bf, daughters=daughters, **dm)
 
@@ -271,7 +271,7 @@ class DecayMode:
 
             daughters = [EvtGenName2PDGIDBiMap[PDGID(d)] for d in daughters]
         except ParticleNotFound:
-            raise ParticleNotFound("Please check your input PDG IDs!")
+            raise ParticleNotFound("Please check your input PDG IDs!") from None
 
         # Override the default settings with the user input, if any
         return cls(bf=bf, daughters=daughters, **info)
@@ -416,8 +416,8 @@ class DecayChain:
         """
         try:
             assert len(decay_chain_dict.keys()) == 1
-        except Exception:
-            raise RuntimeError("Input not in the expected format!")
+        except Exception as e:
+            raise RuntimeError("Input not in the expected format!") from e
 
         def has_no_subdecay(ds):
             return all(isinstance(p, str) for p in ds)

--- a/src/decaylanguage/decay/viewer.py
+++ b/src/decaylanguage/decay/viewer.py
@@ -64,7 +64,7 @@ class DecayChainViewer:
         # Store the input decay chain
         self._chain = decaychain
 
-        # Instantiate the digraph with defaults possibly overriden by user attributes
+        # Instantiate the digraph with defaults possibly overridden by user attributes
         self._graph = self._instantiate_graph(**attrs)
 
         # Build the actual graph from the input decay chain structure
@@ -191,7 +191,7 @@ class DecayChainViewer:
         """
         Return a ``graphviz.dot.Digraph` class instance using the default attributes
         specified in this class:
-        - Default graph attributes are overriden by input by the user.
+        - Default graph attributes are overridden by input by the user.
         - Class and node and edge defaults.
         """
         graph_attr = self._get_graph_defaults()

--- a/src/decaylanguage/decay/viewer.py
+++ b/src/decaylanguage/decay/viewer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
@@ -26,7 +25,7 @@ class GraphNotBuiltError(RuntimeError):
     pass
 
 
-class DecayChainViewer(object):
+class DecayChainViewer:
     """
     The class to visualize a decay chain.
 
@@ -120,7 +119,7 @@ class DecayChainViewer(object):
 
         def new_node_no_subchain(list_parts):
             label = html_table_label(list_parts, bgcolor="#eef3f8")
-            r = "dec{}".format(next(counter))
+            r = f"dec{next(counter)}"
             self.graph.node(r, label=label, style="filled", fillcolor="#eef3f8")
             return r
 
@@ -129,7 +128,7 @@ class DecayChainViewer(object):
                 list(p.keys())[0] if isinstance(p, dict) else p for p in list_parts
             ]
             label = html_table_label(list_parts, add_tags=True)
-            r = "dec{}".format(next(counter))
+            r = f"dec{next(counter)}"
             self.graph.node(r, shape="none", label=label)
             return r
 
@@ -146,9 +145,7 @@ class DecayChainViewer(object):
                     if link_pos is None:
                         self.graph.edge(top_node, _ref, label=str(_bf))
                     else:
-                        self.graph.edge(
-                            "{}:p{}".format(top_node, link_pos), _ref, label=str(_bf)
-                        )
+                        self.graph.edge(f"{top_node}:p{link_pos}", _ref, label=str(_bf))
                 else:
                     _ref_1 = new_node_with_subchain(_list_parts)
                     _bf_1 = subchain[idm]["bf"]
@@ -156,7 +153,7 @@ class DecayChainViewer(object):
                         self.graph.edge(top_node, _ref_1, label=str(_bf_1))
                     else:
                         self.graph.edge(
-                            "{}:p{}".format(top_node, link_pos),
+                            f"{top_node}:p{link_pos}",
                             _ref_1,
                             label=str(_bf_1),
                         )

--- a/src/decaylanguage/modeling/AmpGenReader.ipynb
+++ b/src/decaylanguage/modeling/AmpGenReader.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "source": [
-    "ampgen2goofit('../../models/DtoKpipipi_v2.txt')"
+    "ampgen2goofit(\"../../models/DtoKpipipi_v2.txt\")"
    ],
    "outputs": [
     {

--- a/src/decaylanguage/modeling/__init__.py
+++ b/src/decaylanguage/modeling/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .amplitudechain import LS, AmplitudeChain
 
 __all__ = ("LS", "AmplitudeChain")

--- a/src/decaylanguage/modeling/ampgen2goofit.py
+++ b/src/decaylanguage/modeling/ampgen2goofit.py
@@ -12,10 +12,10 @@ a string output with the converted set of decay chains and variables.
 
 import datetime
 from functools import partial
+from io import StringIO
 
 from particle import SpinType
 from plumbum import colors
-from six import StringIO
 
 from decaylanguage.modeling.goofit import GooFitChain, SF_4Body
 

--- a/src/decaylanguage/modeling/ampgen2goofit.py
+++ b/src/decaylanguage/modeling/ampgen2goofit.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
@@ -10,7 +9,6 @@ This is a function that takes a filename and either prints out or returns
 a string output with the converted set of decay chains and variables.
 """
 
-from __future__ import absolute_import, division, print_function
 
 import datetime
 from functools import partial
@@ -48,7 +46,7 @@ def ampgen2goofit(filename, ret_output=False):
             for p in sorted(GooFitChain.all_particles)
             if p.spin_type == spintype
         ]
-        printer("{spintype.name:>12}:".format(spintype=spintype), *ps)
+        printer(f"{spintype.name:>12}:", *ps)
 
     printer("\n")
     for n, line in enumerate(lines):

--- a/src/decaylanguage/modeling/ampgentransform.py
+++ b/src/decaylanguage/modeling/ampgentransform.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE

--- a/src/decaylanguage/modeling/amplitudechain.py
+++ b/src/decaylanguage/modeling/amplitudechain.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
@@ -8,7 +7,6 @@
 A class representing a set of decays. Can be subclassed to provide custom converters.
 """
 
-from __future__ import absolute_import, division, print_function
 
 import os
 import re
@@ -152,7 +150,7 @@ class AmplitudeChain(ModelDecay):
         elif self.lineshape.startswith("FOCUS"):
             return LS.FOCUS
         else:
-            raise RuntimeError("Unimplemented lineshape {}".format(self.lineshape))
+            raise RuntimeError(f"Unimplemented lineshape {self.lineshape}")
 
     @property
     def full_amp(self):
@@ -184,7 +182,7 @@ class AmplitudeChain(ModelDecay):
     def _get_html(self):
         name = self.particle.html_name
         name = re.sub(
-            r'<SPAN STYLE="text-decoration:overline">(.*)</SPAN>', u"\\1\u0305", name
+            r'<SPAN STYLE="text-decoration:overline">(.*)</SPAN>', "\\1\u0305", name
         )
 
         if self.spinfactor or self.lineshape:

--- a/src/decaylanguage/modeling/decay.py
+++ b/src/decaylanguage/modeling/decay.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
@@ -8,8 +7,6 @@
 A general base class representing decays.
 """
 
-
-from __future__ import absolute_import, division, print_function
 
 import warnings
 from itertools import product
@@ -26,7 +23,7 @@ except ImportError:
 
 
 @attr.s(slots=True)
-class ModelDecay(object):
+class ModelDecay:
     """
     This describes a decay very generally, with search and print features.
     Subclassed for futher usage.

--- a/src/decaylanguage/modeling/decay.py
+++ b/src/decaylanguage/modeling/decay.py
@@ -26,7 +26,7 @@ except ImportError:
 class ModelDecay:
     """
     This describes a decay very generally, with search and print features.
-    Subclassed for futher usage.
+    Subclassed for further usage.
     """
 
     particle = attr.ib()

--- a/src/decaylanguage/modeling/goofit.py
+++ b/src/decaylanguage/modeling/goofit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
@@ -8,7 +7,6 @@
 This is a GooFit adaptor for amplitude chain.
 """
 
-from __future__ import absolute_import, division, print_function
 
 from enum import Enum
 
@@ -75,10 +73,8 @@ class GooFitChain(AmplitudeChain):
     @classmethod
     def make_intro(cls, all_states):
 
-        header = "    // Event type: {} ->  ".format(all_states[0])
-        header += "   ".join(
-            "{} ({})".format(b, a) for a, b in enumerate(all_states[1:])
-        )
+        header = f"    // Event type: {all_states[0]} ->  "
+        header += "   ".join(f"{b} ({a})" for a, b in enumerate(all_states[1:]))
 
         header += """\n
     std::vector<std::vector<Lineshape*>> line_factor_list;
@@ -133,14 +129,12 @@ class GooFitChain(AmplitudeChain):
         elif self.L == 2:
             return SF_4Body.FF_12_34_L2 if norm else SF_4Body.FF_123_4_L2
         else:
-            raise NotImplementedError(
-                "L = {self.L} is not implemented".format(self=self)
-            )
+            raise NotImplementedError(f"L = {self.L} is not implemented")
 
     def spindetails(self):
         if self.decay_structure == DecayStructure.FF_12_34:
-            a = "{}1".format(sprint(self[0].particle.spin_type))
-            b = "{}2".format(sprint(self[1].particle.spin_type))
+            a = f"{sprint(self[0].particle.spin_type)}1"
+            b = f"{sprint(self[1].particle.spin_type)}2"
             return (
                 "Dto{a}{b}_{a}toP1P2_{b}toP3P4"
                 + (
@@ -150,11 +144,11 @@ class GooFitChain(AmplitudeChain):
                 )
             ).format(self=self, a=a, b=b)
         else:
-            a = "{}1".format(sprint(self[0].particle.spin_type))
+            a = f"{sprint(self[0].particle.spin_type)}1"
             if self[0].daughters:
-                b = "{}2".format(sprint(self[0][0].particle.spin_type))
+                b = f"{sprint(self[0][0].particle.spin_type)}2"
             else:
-                raise LineFailure(self, "{} has no daughters".format(self[0]))
+                raise LineFailure(self, f"{self[0]} has no daughters")
             wave = (
                 "{self[0].spinfactor}wave".format(self=self)
                 if self[0].spinfactor and self[0].spinfactor != "S"
@@ -237,9 +231,7 @@ class GooFitChain(AmplitudeChain):
                     + programmatic_name(spline)
                     + "_SplineArr {{\n"
                 )
-                header += strip_pararray(
-                    GooFitChain.pars, "{spline}::Spline::Gamma::".format(spline=spline)
-                )
+                header += strip_pararray(GooFitChain.pars, f"{spline}::Spline::Gamma::")
                 header += "\n    }};\n"
 
         f_scatt = GooFitChain.pars.index[GooFitChain.pars.index.str.contains("f_scatt")]
@@ -276,15 +268,9 @@ class GooFitChain(AmplitudeChain):
                 name=name, par=par, L=L, a=a, b=b
             )
         elif self.ls_enum == LS.GSpline:
-            min = self.__class__.consts.loc[
-                "{self.name}::Spline::Min".format(self=self), "value"
-            ]
-            max = self.__class__.consts.loc[
-                "{self.name}::Spline::Max".format(self=self), "value"
-            ]
-            N = self.__class__.consts.loc[
-                "{self.name}::Spline::N".format(self=self), "value"
-            ]
+            min = self.__class__.consts.loc[f"{self.name}::Spline::Min", "value"]
+            max = self.__class__.consts.loc[f"{self.name}::Spline::Max", "value"]
+            N = self.__class__.consts.loc[f"{self.name}::Spline::N", "value"]
             AdditionalVars = programmatic_name(self.name) + "_SplineArr"
             return """new Lineshapes::GSpline("{name}", {par}_M, {par}_W, {L}, M_{a}{b}, FF::BL2,
             {radius}, {AdditionalVars}, Lineshapes::spline_t({min},{max},{N}))""".format(
@@ -326,7 +312,7 @@ class GooFitChain(AmplitudeChain):
 
         else:
             raise NotImplementedError(
-                "Unimplemented GooFit Lineshape {self.ls_enum.name}".format(self=self)
+                f"Unimplemented GooFit Lineshape {self.ls_enum.name}"
             )
 
     def make_spinfactor(self, final_states):
@@ -391,7 +377,10 @@ class GooFitChain(AmplitudeChain):
 
     @classmethod
     def read_ampgen(cls, *args, **kargs):
-        line_arr, GooFitChain.pars, GooFitChain.consts, all_states = super(
-            GooFitChain, cls
-        ).read_ampgen(*args, **kargs)
+        (
+            line_arr,
+            GooFitChain.pars,
+            GooFitChain.consts,
+            all_states,
+        ) = super().read_ampgen(*args, **kargs)
         return line_arr, all_states

--- a/src/decaylanguage/modeling/goofit.py
+++ b/src/decaylanguage/modeling/goofit.py
@@ -166,7 +166,7 @@ class GooFitChain(AmplitudeChain):
 
         raise LineFailure(
             self,
-            "Spinfactors not currenly included!: {spindet}".format(
+            "Spinfactors not currently included!: {spindet}".format(
                 spindet=self.spindetails()
             ),
         )

--- a/src/decaylanguage/utils/__init__.py
+++ b/src/decaylanguage/utils/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from .errors import LineFailure
 from .particleutils import charge_conjugate_name
 from .utilities import filter_lines, iter_flatten, split

--- a/src/decaylanguage/utils/errors.py
+++ b/src/decaylanguage/utils/errors.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/decaylanguage for details.
 
-from __future__ import absolute_import, division, print_function
-
 
 class LineFailure(RuntimeError):
     def __init__(self, line, message):
-        super(LineFailure, self).__init__("{}: {}".format(line, message))
+        super().__init__(f"{line}: {message}")

--- a/src/decaylanguage/utils/particleutils.py
+++ b/src/decaylanguage/utils/particleutils.py
@@ -4,7 +4,6 @@
 # or https://github.com/scikit-hep/decaylanguage for details.
 
 
-import sys
 from functools import lru_cache
 
 from particle import Particle

--- a/src/decaylanguage/utils/particleutils.py
+++ b/src/decaylanguage/utils/particleutils.py
@@ -1,12 +1,11 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/decaylanguage for details.
 
-from __future__ import absolute_import
 
 import sys
+from functools import lru_cache
 
 from particle import Particle
 from particle.converters import (
@@ -16,14 +15,7 @@ from particle.converters import (
 )
 from particle.exceptions import MatchingIDNotFound
 
-if sys.version_info < (3,):
-    from cachetools import LFUCache, cached
-
-    cacher = cached(cache=LFUCache(maxsize=64))
-else:
-    from functools import lru_cache
-
-    cacher = lru_cache(maxsize=64)
+cacher = lru_cache(maxsize=64)
 
 
 @cacher
@@ -62,7 +54,7 @@ def charge_conjugate_name(name, pdg_name=False):
             # Convert the EvtGen name back to a PDG name, to match input type
             return EvtGen2PDGNameMap[ccname]
         except MatchingIDNotFound:  # Catch issue in PDG2EvtGenNameMap matching
-            return "ChargeConj({})".format(name)
+            return f"ChargeConj({name})"
 
     # Dealing only with EvtGen names at this stage
     try:
@@ -71,4 +63,4 @@ def charge_conjugate_name(name, pdg_name=False):
         try:
             return EvtGenName2PDGIDBiMap[-EvtGenName2PDGIDBiMap[name]]
         except Exception:
-            return "ChargeConj({})".format(name)
+            return f"ChargeConj({name})"

--- a/src/decaylanguage/utils/utilities.py
+++ b/src/decaylanguage/utils/utilities.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/decaylanguage for details.
-
-from __future__ import absolute_import, division, print_function
 
 
 def iter_flatten(iterable):
@@ -13,8 +10,7 @@ def iter_flatten(iterable):
     """
     for e in iterable:
         if isinstance(e, (list, tuple)):
-            for f in iter_flatten(e):
-                yield f
+            yield from iter_flatten(e)
         else:
             yield e
 

--- a/tests/dec/test_dec.py
+++ b/tests/dec/test_dec.py
@@ -4,14 +4,9 @@
 # or https://github.com/scikit-hep/decaylanguage for details.
 
 import sys
+from pathlib import Path
 
 import pytest
-
-try:
-    from pathlib2 import Path
-except ImportError:
-    from pathlib import Path
-
 from lark import Token, Tree
 
 from decaylanguage.dec.dec import (
@@ -26,9 +21,6 @@ from decaylanguage.dec.dec import (
     get_model_parameters,
 )
 from decaylanguage.dec.enums import known_decay_models
-
-if sys.version_info < (3,):
-    FileNotFoundError = IOError
 
 
 DIR = Path(__file__).parent.resolve()

--- a/tests/dec/test_dec.py
+++ b/tests/dec/test_dec.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE

--- a/tests/dec/test_dec.py
+++ b/tests/dec/test_dec.py
@@ -3,7 +3,6 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/decaylanguage for details.
 
-import sys
 from pathlib import Path
 
 import pytest
@@ -21,7 +20,6 @@ from decaylanguage.dec.dec import (
     get_model_parameters,
 )
 from decaylanguage.dec.enums import known_decay_models
-
 
 DIR = Path(__file__).parent.resolve()
 

--- a/tests/dec/test_issues.py
+++ b/tests/dec/test_issues.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2020, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE

--- a/tests/dec/test_issues.py
+++ b/tests/dec/test_issues.py
@@ -3,13 +3,10 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/decaylanguage for details.
 
+from pathlib import Path
+
 import pytest
 from lark import UnexpectedToken
-
-try:
-    from pathlib2 import Path
-except ImportError:
-    from pathlib import Path
 
 from decaylanguage.dec.dec import DecFileParser
 

--- a/tests/decay/test_decay.py
+++ b/tests/decay/test_decay.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE

--- a/tests/decay/test_viewer.py
+++ b/tests/decay/test_viewer.py
@@ -1,11 +1,8 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/decaylanguage for details.
 
-
-from __future__ import absolute_import
 
 try:
     from pathlib2 import Path

--- a/tests/decay/test_viewer.py
+++ b/tests/decay/test_viewer.py
@@ -4,10 +4,7 @@
 # or https://github.com/scikit-hep/decaylanguage for details.
 
 
-try:
-    from pathlib2 import Path
-except ImportError:
-    from pathlib import Path
+from pathlib import Path
 
 import pytest
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -3,14 +3,11 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/decaylanguage for details.
 
-from decaylanguage.modeling.ampgen2goofit import ampgen2goofit
-
-try:
-    from pathlib2 import Path
-except ImportError:
-    from pathlib import Path
+from pathlib import Path
 
 import pytest
+
+from decaylanguage.modeling.ampgen2goofit import ampgen2goofit
 
 DIR = Path(__file__).parent.resolve()
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE

--- a/tests/test_dec_full.py
+++ b/tests/test_dec_full.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE

--- a/tests/test_decaylanguage.py
+++ b/tests/test_decaylanguage.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE

--- a/tests/test_goofit.py
+++ b/tests/test_goofit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, Eduardo Rodrigues and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE


### PR DESCRIPTION
Removes Python 2 and 3.5 support.


- chore: bump pre-commit
- chore: pre-commit py3
- style: autofixes
- style: manual fixes
- chore: drop six
- chore: drop py2 backports
- tests: use pyproject config, pytest 6+
