### PR TITLE
chore: simpler dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,3 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    ignore:
-      - dependency-name: "actions/*"
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
Ignores no longer needed after April 2022. Dependabot keeps the same style pinning now.