### PR TITLE
tests: enable checking for warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,3 +110,6 @@ addopts = [
     "--strict-config",
 ]
 log_cli_level = "DEBUG"
+filterwarnings = [
+    "error",
+]


### PR DESCRIPTION
Missing from the test config.