### PR TITLE
ci: update to Python 3.11 final

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.10', '3.11-dev']
+        python-version: ['3.7', '3.8', '3.10', '3.11']
         include:
           - {os: macos-latest, python-version: '3.9'}
           - {os: windows-latest, python-version: '3.7'}


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos