### PR TITLE
Move particle finding functions for AmpGen names to this package

### DIFF
--- a/src/decaylanguage/utils/particleutils.py
+++ b/src/decaylanguage/utils/particleutils.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import re
 from functools import lru_cache
 
+from typing import Any
+
 from particle import Particle, ParticleNotFound
 from particle.converters import (
     EvtGen2PDGNameMap,
@@ -16,6 +18,7 @@ from particle.converters import (
     PDG2EvtGenNameMap,
 )
 from particle.exceptions import MatchingIDNotFound
+from particle.particle.enums import Charge_mapping
 
 cacher = lru_cache(maxsize=64)
 

--- a/src/decaylanguage/utils/particleutils.py
+++ b/src/decaylanguage/utils/particleutils.py
@@ -6,8 +6,8 @@
 
 from __future__ import annotations
 
-from functools import lru_cache
 import re
+from functools import lru_cache
 
 from particle import Particle, ParticleNotFound
 from particle.converters import (

--- a/src/decaylanguage/utils/particleutils.py
+++ b/src/decaylanguage/utils/particleutils.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import re
 from functools import lru_cache
-
 from typing import Any
 
 from particle import Particle, ParticleNotFound

--- a/src/decaylanguage/utils/particleutils.py
+++ b/src/decaylanguage/utils/particleutils.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
+import re
 
 from particle import Particle, ParticleNotFound
 from particle.converters import (
@@ -100,7 +101,7 @@ def particle_list_from_string_name(name: str) -> list[Particle]:
     if list_can:
         return list_can
 
-    mat_str = getname.match(short_name)
+    mat_str = _getname.match(short_name)
 
     if mat_str is None:
         return []
@@ -165,3 +166,20 @@ def _from_group_dict_list(mat: dict[str, Any]) -> list[Particle]:
         return sorted(vals)
 
     return vals
+
+
+_getname = re.compile(
+    r"""
+^                                           # Beginning of string
+      (?P<name>       \w+?        )         # One or more characters, non-greedy
+(?:\( (?P<family>    [udsctb][\w]*) \) )?   # Optional family like (s)
+(?:\( (?P<state>      \d+         ) \)      # Optional state in ()
+      (?=             \*? \(      )  )?     #   - lookahead for mass
+      (?P<star>       \*          )?        # Optional star
+(?:\( (?P<mass>       \d+         ) \) )?   # Optional mass in ()
+      (?P<bar>        (bar|~)     )?        # Optional bar
+      (?P<charge>     [0\+\-][+-]?)         # Required 0, -, --, or +, ++
+$                                           # End of string
+""",
+    re.VERBOSE,
+)

--- a/src/decaylanguage/utils/particleutils.py
+++ b/src/decaylanguage/utils/particleutils.py
@@ -76,7 +76,9 @@ def particle_from_string_name(name: str) -> Particle:
     matches = particle_list_from_string_name(name)
     if matches:
         return matches[0]
-    raise ParticleNotFound(f"Particle with AmpGen style name {name!r} not found in particle table")
+    raise ParticleNotFound(
+        f"Particle with AmpGen style name {name!r} not found in particle table"
+    )
 
 
 def particle_list_from_string_name(name: str) -> list[Particle]:

--- a/tests/utils/test_particleutils.py
+++ b/tests/utils/test_particleutils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import pytest
 
-from decaylanguage.utils.particleutils import charge_conjugate_name
+from decaylanguage.utils.particleutils import charge_conjugate_name, particle_from_string_name
 
 matches_evtgen = (
     ("pi0", "pi0"),
@@ -34,3 +34,44 @@ def test_charge_conjugate_name_defaults(p_name, ccp_name):
 @pytest.mark.parametrize(("p_name", "ccp_name"), matches_pdg)
 def test_charge_conjugate_name_with_pdg_name(p_name, ccp_name):
     assert charge_conjugate_name(p_name, pdg_name=True) == ccp_name
+
+
+def test_particle_from_string_name():
+    pi = particle_from_string_name("pi+")
+    assert pi.pdgid == 211
+
+    with pytest.raises(ParticleNotFound):
+        Particle.from_string("unknown")
+
+
+def test_fuzzy_string():
+    """
+    The input name is not specific enough, in which case the search is done
+    by pdg_name after failing a match by name.
+    """
+    p = particle_from_string_name("a(0)(980)")  # all 3 charge stages match
+    assert p.pdgid == 9000111
+
+
+ampgen_style_names = (
+    ("b", 5),
+    ("b~", -5),
+    ("pi+", 211),
+    ("pi-", -211),
+    ("K~*0", -313),
+    ("K*(892)bar0", -313),
+    ("a(1)(1260)+", 20213),
+    ("rho(1450)0", 100113),
+    ("rho(770)0", 113),
+    ("K(1)(1270)bar-", -10323),
+    # ("K(1460)bar-", -100321),
+    ("K(2)*(1430)bar-", -325),
+)
+
+
+@pytest.mark.parametrize(("name", "pid"), ampgen_style_names)
+def test_ampgen_style_names(name, pid):
+    particle = particle_from_string_name(name)
+
+    assert particle.pdgid == pid
+    assert particle == pid

--- a/tests/utils/test_particleutils.py
+++ b/tests/utils/test_particleutils.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import pytest
-
 from particle import ParticleNotFound
 
 from decaylanguage.utils.particleutils import (

--- a/tests/utils/test_particleutils.py
+++ b/tests/utils/test_particleutils.py
@@ -7,7 +7,10 @@ from __future__ import annotations
 
 import pytest
 
-from decaylanguage.utils.particleutils import charge_conjugate_name, particle_from_string_name
+from decaylanguage.utils.particleutils import (
+    charge_conjugate_name,
+    particle_from_string_name,
+)
 
 matches_evtgen = (
     ("pi0", "pi0"),

--- a/tests/utils/test_particleutils.py
+++ b/tests/utils/test_particleutils.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import pytest
 
+from particle import ParticleNotFound
+
 from decaylanguage.utils.particleutils import (
     charge_conjugate_name,
     particle_from_string_name,
@@ -44,7 +46,7 @@ def test_particle_from_string_name():
     assert pi.pdgid == 211
 
     with pytest.raises(ParticleNotFound):
-        Particle.from_string("unknown")
+        particle_from_string_name("unknown")
 
 
 def test_fuzzy_string():


### PR DESCRIPTION
Related to MR https://github.com/scikit-hep/particle/pull/354 in `Particle`, see discussions there.

This move is to somewhat clean-up `Particle` and have here the 2 functions that are only needed in `DecayLanguage`'s modeling submodule to deal with AmpGen. For reference, there are ongoing discussions to make this all redundant, at which point these fuctions will also become unnecessary.

CC @henryiii, @jonas-eschle.