### PR TITLE
DecayChain.from_dict only supports single decay chains

### DIFF
--- a/src/decaylanguage/decay/decay.py
+++ b/src/decaylanguage/decay/decay.py
@@ -471,72 +471,72 @@ def _build_decay_modes(
     decay_modes: dict[str, DecayMode], dc_dict: DecayChainDict
 ) -> None:
     """
-    Internal recursive function that identifies and creates all `DecayMode` instances
-    effectively contained in the dict representation of a `DecayChain`,
-    which is for example the format returned by `DecFileParser.build_decay_chains(...)`,
+     Internal recursive function that identifies and creates all `DecayMode` instances
+     effectively contained in the dict representation of a `DecayChain`,
+     which is for example the format returned by `DecFileParser.build_decay_chains(...)`,
 
-    Given the input dict representation of a `DecayChain`
-    it returns a dict of mother particles and their final states as `DecayMode` instances.
+     Given the input dict representation of a `DecayChain`
+     it returns a dict of mother particles and their final states as `DecayMode` instances.
 
-    Parameters
-    ----------
-    decay_modes: dict
-        A dict to be populated with the decay modes `DecayMode`
-        built from the input decay chain dictionary.
-    dc_dict: dict
-        The input decay chain dictionary.
+     Parameters
+     ----------
+     decay_modes: dict
+         A dict to be populated with the decay modes `DecayMode`
+         built from the input decay chain dictionary.
+     dc_dict: dict
+         The input decay chain dictionary.
 
-    Note
-    ----
-    Only single chains are supported, meaning every decaying particle
-    can only define a single decay mode.
+     Note
+     ----
+     Only single chains are supported, meaning every decaying particle
+     can only define a single decay mode.
 
-   Examples
-   --------
-   The simple example with no sub-decays:
-   >>> dc_dict = {
-       "anti-D0": [
-           {
-             "bf": 1.0,
-             "fs": ["K+", "pi-"],
-             "model": "PHSP",
-             "model_params": ""
-           }
-       ]
-   }
-   >>> # It provides
-   >>> decay_modes = {}
-   >>> _build_decay_modes(decay_modes, dc_dict)
-   >>> decay_modes
-   {'anti-D0': <DecayMode: daughters=K+ pi-, BF=1.0>}
-
-    A more complicated example with a sub-decay and more than one mode:
-    {
-        "anti-D*0": [
+    Examples
+    --------
+    The simple example with no sub-decays:
+    >>> dc_dict = {
+        "anti-D0": [
             {
-                "bf": 0.619,
-                "fs": [
-                    {
-                        "anti-D0": [
-                            {
-                                "bf": 1.0,
-                                "fs": ["K+", "pi-"],
-                                "model": "PHSP",
-                                "model_params": ""
-                            }
-                        ]
-                    },
-                    "pi0"
-                ],
-                "model": "VSS",
-                "model_params": ""
+              "bf": 1.0,
+              "fs": ["K+", "pi-"],
+              "model": "PHSP",
+              "model_params": ""
             }
         ]
     }
-    It provides
+    >>> # It provides
+    >>> decay_modes = {}
+    >>> _build_decay_modes(decay_modes, dc_dict)
     >>> decay_modes
-    {'anti-D0': <DecayMode: daughters=K+ pi-, BF=1.0>,
-     'anti-D*0': <DecayMode: daughters=anti-D0 pi0, BF=0.619>}
+    {'anti-D0': <DecayMode: daughters=K+ pi-, BF=1.0>}
+
+     A more complicated example with a sub-decay and more than one mode:
+     {
+         "anti-D*0": [
+             {
+                 "bf": 0.619,
+                 "fs": [
+                     {
+                         "anti-D0": [
+                             {
+                                 "bf": 1.0,
+                                 "fs": ["K+", "pi-"],
+                                 "model": "PHSP",
+                                 "model_params": ""
+                             }
+                         ]
+                     },
+                     "pi0"
+                 ],
+                 "model": "VSS",
+                 "model_params": ""
+             }
+         ]
+     }
+     It provides
+     >>> decay_modes
+     {'anti-D0': <DecayMode: daughters=K+ pi-, BF=1.0>,
+      'anti-D*0': <DecayMode: daughters=anti-D0 pi0, BF=0.619>}
     """
     mother = list(dc_dict.keys())[0]
     dms = dc_dict[mother]

--- a/src/decaylanguage/decay/decay.py
+++ b/src/decaylanguage/decay/decay.py
@@ -471,25 +471,25 @@ def _build_decay_modes(
     decay_modes: dict[str, DecayMode], dc_dict: DecayChainDict
 ) -> None:
     """
-     Internal recursive function that identifies and creates all `DecayMode` instances
-     effectively contained in the dict representation of a `DecayChain`,
-     which is for example the format returned by `DecFileParser.build_decay_chains(...)`,
+    Internal recursive function that identifies and creates all `DecayMode` instances
+    effectively contained in the dict representation of a `DecayChain`,
+    which is for example the format returned by `DecFileParser.build_decay_chains(...)`,
 
-     Given the input dict representation of a `DecayChain`
-     it returns a dict of mother particles and their final states as `DecayMode` instances.
+    Given the input dict representation of a `DecayChain`
+    it returns a dict of mother particles and their final states as `DecayMode` instances.
 
-     Parameters
-     ----------
-     decay_modes: dict
-         A dict to be populated with the decay modes `DecayMode`
-         built from the input decay chain dictionary.
-     dc_dict: dict
-         The input decay chain dictionary.
+    Parameters
+    ----------
+    decay_modes: dict
+        A dict to be populated with the decay modes `DecayMode`
+        built from the input decay chain dictionary.
+    dc_dict: dict
+        The input decay chain dictionary.
 
-     Note
-     ----
-     Only single chains are supported, meaning every decaying particle
-     can only define a single decay mode.
+    Note
+    ----
+    Only single chains are supported, meaning every decaying particle
+    can only define a single decay mode.
 
     Examples
     --------
@@ -510,33 +510,33 @@ def _build_decay_modes(
     >>> decay_modes
     {'anti-D0': <DecayMode: daughters=K+ pi-, BF=1.0>}
 
-     A more complicated example with a sub-decay and more than one mode:
-     {
-         "anti-D*0": [
-             {
-                 "bf": 0.619,
-                 "fs": [
-                     {
-                         "anti-D0": [
-                             {
-                                 "bf": 1.0,
-                                 "fs": ["K+", "pi-"],
-                                 "model": "PHSP",
-                                 "model_params": ""
-                             }
-                         ]
-                     },
-                     "pi0"
-                 ],
-                 "model": "VSS",
-                 "model_params": ""
-             }
-         ]
-     }
-     It provides
-     >>> decay_modes
-     {'anti-D0': <DecayMode: daughters=K+ pi-, BF=1.0>,
-      'anti-D*0': <DecayMode: daughters=anti-D0 pi0, BF=0.619>}
+    A more complicated example with a sub-decay and more than one mode:
+    {
+        "anti-D*0": [
+            {
+                "bf": 0.619,
+                "fs": [
+                    {
+                        "anti-D0": [
+                            {
+                                "bf": 1.0,
+                                "fs": ["K+", "pi-"],
+                                "model": "PHSP",
+                                "model_params": ""
+                            }
+                        ]
+                    },
+                    "pi0"
+                ],
+                "model": "VSS",
+                "model_params": ""
+            }
+        ]
+    }
+    It provides
+    >>> decay_modes
+    {'anti-D0': <DecayMode: daughters=K+ pi-, BF=1.0>,
+     'anti-D*0': <DecayMode: daughters=anti-D0 pi0, BF=0.619>}
     """
     mother = list(dc_dict.keys())[0]
     dms = dc_dict[mother]

--- a/src/decaylanguage/decay/decay.py
+++ b/src/decaylanguage/decay/decay.py
@@ -495,22 +495,22 @@ def _build_decay_modes(
     --------
     The simple example with no sub-decays:
     >>> dc_dict = {
-        "anti-D0": [
-            {
-              "bf": 1.0,
-              "fs": ["K+", "pi-"],
-              "model": "PHSP",
-              "model_params": ""
-            }
-        ]
-    }
+    ...     "anti-D0": [
+    ...         {
+    ...           "bf": 1.0,
+    ...           "fs": ["K+", "pi-"],
+    ...           "model": "PHSP",
+    ...           "model_params": ""
+    ...         }
+    ...     ]
+    ... }
     >>> # It provides
     >>> decay_modes = {}
     >>> _build_decay_modes(decay_modes, dc_dict)
     >>> decay_modes
     {'anti-D0': <DecayMode: daughters=K+ pi-, BF=1.0>}
 
-    A more complicated example with a sub-decay and more than one mode:
+    A more complicated example with a sub-decay and more than one mode
     {
         "anti-D*0": [
             {
@@ -533,8 +533,7 @@ def _build_decay_modes(
             }
         ]
     }
-    It provides
-    >>> decay_modes
+    provides
     {'anti-D0': <DecayMode: daughters=K+ pi-, BF=1.0>,
      'anti-D*0': <DecayMode: daughters=anti-D0 pi0, BF=0.619>}
     """

--- a/tests/decay/test_decay.py
+++ b/tests/decay/test_decay.py
@@ -314,6 +314,19 @@ def test_DecayChain_constructor_from_dict():
     assert DecayChain.from_dict(dc_dict).to_dict() == dc_dict
 
 
+def test_DecayChain_constructor_from_dict_multiple_final_states():
+    dc_dict = {'MyD-': [{'bf': 0.905,
+                         'fs': ['K+', 'pi-', 'pi-'],
+                         'model': 'D_DALITZ',
+                         'model_params': ''},
+                         {'bf': 0.095,
+                          'fs': ['K+', 'K-', 'pi-'],
+                          'model': 'D_DALITZ',
+                          'model_params': ''}]}
+    with pytest.raises(RuntimeError):
+        _ = DecayChain.from_dict(dc_dict)
+
+
 def test_DecayChain_constructor_from_dict_RuntimeError(dc2):
     # For the sake of example remove some parts of a valid dict
     bad_dict_repr = dc2.to_dict()["D*+"][0]

--- a/tests/decay/test_decay.py
+++ b/tests/decay/test_decay.py
@@ -315,14 +315,22 @@ def test_DecayChain_constructor_from_dict():
 
 
 def test_DecayChain_constructor_from_dict_multiple_final_states():
-    dc_dict = {'MyD-': [{'bf': 0.905,
-                         'fs': ['K+', 'pi-', 'pi-'],
-                         'model': 'D_DALITZ',
-                         'model_params': ''},
-                         {'bf': 0.095,
-                          'fs': ['K+', 'K-', 'pi-'],
-                          'model': 'D_DALITZ',
-                          'model_params': ''}]}
+    dc_dict = {
+        "MyD-": [
+            {
+                "bf": 0.905,
+                "fs": ["K+", "pi-", "pi-"],
+                "model": "D_DALITZ",
+                "model_params": "",
+            },
+            {
+                "bf": 0.095,
+                "fs": ["K+", "K-", "pi-"],
+                "model": "D_DALITZ",
+                "model_params": "",
+            },
+        ]
+    }
     with pytest.raises(RuntimeError):
         _ = DecayChain.from_dict(dc_dict)
 


### PR DESCRIPTION
The DecayChain.from_dict constructor has buggy and given a dict describing a chain with a particle having multiple final states it would silently pick up the last one parsed. Now it raises an exception since non-single decay chains are not supported in the class.

While at it, docs enhanced with explanations and examples.