### PR TITLE
chore: target-version no longer needed by Black or Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,6 @@ extend-ignore = [
   "E501",   # Line too long
   "PT013",  # Incorrect import of pytest
 ]
-target-version = "py37"
 src = ["src"]
 unfixable = [
   "T20",  # Removes print statements


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/issues/201.

Committed via https://github.com/asottile/all-repos