### PR TITLE
Simplify the decay file parsing grammar and implement more get methods for EvtGen keywords + unit tests

### DIFF
--- a/src/decaylanguage/data/decfile.lark
+++ b/src/decaylanguage/data/decfile.lark
@@ -18,7 +18,7 @@ setlsbw : "BlattWeisskopf" label value // Set Blatt-Weisskopf barrier factor for
 
 setlspw : "SetLineshapePW" LABEL LABEL LABEL INT // Redefine Partial Wave for label -> label label
 
-cdecay : "CDecay" label
+cdecay : "CDecay" LABEL
 
 define : "Define" label value
 
@@ -26,11 +26,13 @@ particle_def: "Particle" label value value // Set the mass and width of a partic
 
 model_alias : "ModelAlias" model_label model
 
-alias : "Alias" label label
+alias : "Alias" LABEL LABEL
 
 chargeconj : "ChargeConj" label label
 
-changemasslimit : ("ChangeMassMin" | "ChangeMassMax") label value // Set upper/lower mass cuts on a lineshape
+changemasslimit : LABEL_CHANGE_MASS LABEL SIGNED_NUMBER // Set upper/lower mass cuts on a lineshape
+
+LABEL_CHANGE_MASS : "ChangeMassMin" | "ChangeMassMax"
 
 ?commands : global_photos
 

--- a/src/decaylanguage/data/decfile.lark
+++ b/src/decaylanguage/data/decfile.lark
@@ -20,7 +20,7 @@ setlspw : "SetLineshapePW" LABEL LABEL LABEL INT // Redefine Partial Wave for la
 
 cdecay : "CDecay" LABEL
 
-define : "Define" label value
+define : "Define" LABEL SIGNED_NUMBER
 
 particle_def: "Particle" label value value // Set the mass and width of a particle (in GeV)
 

--- a/src/decaylanguage/data/decfile.lark
+++ b/src/decaylanguage/data/decfile.lark
@@ -18,7 +18,7 @@ LABEL_LINESHAPE : "LSFLAT" | "LSNONRELBW"
 
 inc_factor: ("IncludeBirthFactor" | "IncludeDecayFactor") label ("yes" | "no") // Presence of the birth/decay factor and form-factor
 
-setlsbw : "BlattWeisskopf" label value // Set Blatt-Weisskopf barrier factor for a lineshape
+setlsbw : "BlattWeisskopf" LABEL SIGNED_NUMBER // Set Blatt-Weisskopf barrier factor for a lineshape
 
 setlspw : "SetLineshapePW" LABEL LABEL LABEL INT // Redefine Partial Wave for label -> label label
 

--- a/src/decaylanguage/data/decfile.lark
+++ b/src/decaylanguage/data/decfile.lark
@@ -28,7 +28,7 @@ model_alias : "ModelAlias" model_label model
 
 alias : "Alias" LABEL LABEL
 
-chargeconj : "ChargeConj" label label
+chargeconj : "ChargeConj" LABEL LABEL
 
 changemasslimit : LABEL_CHANGE_MASS LABEL SIGNED_NUMBER // Set upper/lower mass cuts on a lineshape
 

--- a/src/decaylanguage/data/decfile.lark
+++ b/src/decaylanguage/data/decfile.lark
@@ -14,7 +14,7 @@ jetset_def : "JetSetPar" LABEL "=" SIGNED_NUMBER
 
 ls_def : LABEL_LINESHAPE LABEL // Choose a lineshape for a particle
 
-LABEL_LINESHAPE : "LSFLAT" | "LSNONRELBW"
+LABEL_LINESHAPE : "LSFLAT" | "LSNONRELBW" | "LSMANYDELTAFUNC"
 
 inc_factor: ("IncludeBirthFactor" | "IncludeDecayFactor") label ("yes" | "no") // Presence of the birth/decay factor and form-factor
 

--- a/src/decaylanguage/data/decfile.lark
+++ b/src/decaylanguage/data/decfile.lark
@@ -6,11 +6,15 @@
 start : _NEWLINE* (line _NEWLINE+)* ("End" _NEWLINE+)?
 ?line : define | particle_def | pythia_def | jetset_def | ls_def | model_alias | alias | chargeconj | commands | decay | cdecay | copydecay | setlspw | setlsbw | changemasslimit | inc_factor
 
-pythia_def : ("PythiaBothParam" | "PythiaAliasParam") LABEL ":" LABEL "=" (LABEL | SIGNED_NUMBER)
+pythia_def : LABEL_PYTHIA_PARAMETERS LABEL ":" LABEL "=" (LABEL | SIGNED_NUMBER)
+
+LABEL_PYTHIA_PARAMETERS : "PythiaBothParam" | "PythiaAliasParam"
 
 jetset_def : "JetSetPar" LABEL "=" SIGNED_NUMBER
 
-ls_def : ("LSFLAT" | "LSNONRELBW") label // Choose a lineshape for a particle
+ls_def : LABEL_LINESHAPE LABEL // Choose a lineshape for a particle
+
+LABEL_LINESHAPE : "LSFLAT" | "LSNONRELBW"
 
 inc_factor: ("IncludeBirthFactor" | "IncludeDecayFactor") label ("yes" | "no") // Presence of the birth/decay factor and form-factor
 

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -1668,11 +1668,11 @@ def get_lineshape_settings(
      Return a dictionary of all lineshape settings,
      with keys corresponding to particle names or aliases, as
      {PARTICLE1: {'lineshape': 'NAME1',  # E.g. "LSFLAT" or "LSNONRELBW"
-       'BlattWeisskopf': VALUE1,
+       'BlattWeisskopf': VALUE11,
        'ChangeMassMin': VALUE12,
        'ChangeMassMax': VALUE13},
       PARTICLE2: {'lineshape': 'NAME2',
-       'BlattWeisskopf': VALUE2,
+       'BlattWeisskopf': VALUE21,
        'ChangeMassMin': VALUE22,
        'ChangeMassMax': VALUE23},
        ...

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -1390,7 +1390,7 @@ def get_charge_conjugate_decays(parsed_file: Tree) -> list[str]:
 
     try:
         return sorted(
-            tree.children[0].children[0].value
+            tree.children[0].value
             for tree in parsed_file.find_data("cdecay")
         )
     except Exception as err:
@@ -1485,7 +1485,7 @@ def get_aliases(parsed_file: Tree) -> dict[str, str]:
     """
     try:
         return {
-            tree.children[0].children[0].value: tree.children[1].children[0].value
+            tree.children[0].value: tree.children[1].value
             for tree in parsed_file.find_data("alias")
         }
     except Exception as err:

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -1434,9 +1434,7 @@ def get_definitions(parsed_file: Tree) -> dict[str, float]:
     """
     try:
         return {
-            tree.children[0]
-            .children[0]
-            .value: float(tree.children[1].children[0].value)
+            tree.children[0].value: float(tree.children[1].value)
             for tree in parsed_file.find_data("define")
         }
     except Exception as err:

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -1505,7 +1505,7 @@ def get_charge_conjugate_defs(parsed_file: Tree) -> dict[str, str]:
     """
     try:
         return {
-            tree.children[0].children[0].value: tree.children[1].children[0].value
+            tree.children[0].value: tree.children[1].value
             for tree in parsed_file.find_data("chargeconj")
         }
     except Exception as err:

--- a/tests/dec/test_dec.py
+++ b/tests/dec/test_dec.py
@@ -227,11 +227,36 @@ def test_jetset_definitions_parsing():
     }
 
 
-def test_list_lineshape_definitions():
+def test_dict_lineshape_settings():
     p = DecFileParser(DIR / "../data/defs-aliases-chargeconj.dec")
     p.parse()
 
-    assert p.list_lineshape_definitions() == [
+    assert p.dict_lineshape_settings() == {
+        "MyK*0": {
+            "lineshape": "LSNONRELBW",
+            "BlattWeisskopf": 0.0,
+            "ChangeMassMin": 0.5,
+            "ChangeMassMax": 3.5,
+        },
+        "MyPhi": {
+            "lineshape": "LSNONRELBW",
+            "BlattWeisskopf": 0.0,
+            "ChangeMassMin": 1.0,
+            "ChangeMassMax": 1.04,
+        },
+        "MyKS0pipi": {
+            "lineshape": "LSFLAT",
+            "ChangeMassMin": 1.1,
+            "ChangeMassMax": 2.4,
+        },
+    }
+
+
+def test_list_lineshapePW_definitions():
+    p = DecFileParser(DIR / "../data/defs-aliases-chargeconj.dec")
+    p.parse()
+
+    assert p.list_lineshapePW_definitions() == [
         (["D_1+", "D*+", "pi0"], 2),
         (["D_1+", "D*0", "pi+"], 2),
         (["D_1-", "D*-", "pi0"], 2),

--- a/tests/dec/test_dec.py
+++ b/tests/dec/test_dec.py
@@ -202,12 +202,16 @@ def test_pythia_definitions_parsing():
     p.parse()
 
     assert p.dict_pythia_definitions() == {
-        "ParticleDecays:mixB": "off",
-        "Init:showChangedSettings": "off",
-        "Init:showChangedParticleData": "off",
-        "Next:numberShowEvent": 0.0,
-        "ParticleDecays:sophisticatedTau": 3,
-        "ParticleDecays:tauPolarization": -1.0,
+        "PythiaAliasParam": {
+            "ParticleDecays:sophisticatedTau": 3.0,
+            "ParticleDecays:tauPolarization": -1.0,
+        },
+        "PythiaBothParam": {
+            "Init:showChangedParticleData": "off",
+            "Init:showChangedSettings": "off",
+            "Next:numberShowEvent": 0.0,
+            "ParticleDecays:mixB": "off",
+        },
     }
 
 


### PR DESCRIPTION
Hi @henryiii, I realised while working on get methods for recently introduced EvtGen  keywords that (1) some rules with more than one possible label cannot presently be disentangled (e.g. "ChangeMassMin" and "ChangeMassMax") and (2) the grammar can anyway be simplified, potentially making things slightly faster.

I will be adding more here but would welcome your opinion on these simplifications in case I am missing something - I think not and this has no cons, just pros. Advance thanks.