### PR TITLE
Allow dec file Decay statements to effectively be able to set a particle as stable

### DIFF
--- a/src/decaylanguage/data/decfile.lark
+++ b/src/decaylanguage/data/decfile.lark
@@ -12,7 +12,7 @@ jetset_def : "JetSetPar" LABEL "=" SIGNED_NUMBER
 
 ls_def : ("LSFLAT" | "LSNONRELBW") label // Choose a lineshape for a particle
 
-inc_factor: ("IncludeBirthFactor" | "IncludeDecayFactor") label ("yes" | "no") // Presence of the birth/decay factor and form-factor
+inc_factor: ("IncludeBirthFactor" | "IncludeDecayFactor") label ("yes" | "no") // Presence of the birth/decay momentum factor and form-factor
 
 setlsbw : "BlattWeisskopf" label value // Set Blatt-Weisskopf barrier factor for a lineshape
 
@@ -39,7 +39,7 @@ global_photos : boolean_photos
 boolean_photos : "yesPhotos" -> yes
                 | "noPhotos"  -> no
 
-decay : "Decay" particle _NEWLINE+ decayline+ "Enddecay"
+decay : "Decay" particle _NEWLINE+ decayline* "Enddecay"
 decayline : value particle* photos? model _NEWLINE+
 value : SIGNED_NUMBER
 photos : "PHOTOS"

--- a/tests/data/minimalistic.dec
+++ b/tests/data/minimalistic.dec
@@ -1,7 +1,7 @@
 # Example decfile for testing purposes:
 
 # Line with "End" is strictly speaking not necessary
-# Such "empty" files are relevant in LHCb for example when special decays are all defined in PYthon code
+# Such "empty" files are relevant in LHCb for example when special decays are all defined in Python code
 # inserted in commented-out lines
 End
 #

--- a/tests/data/test_stable-particle.dec
+++ b/tests/data/test_stable-particle.dec
@@ -1,0 +1,7 @@
+# Example decay chain for testing purposes:
+# An empty list of decay modes makes the particle stable!
+
+Decay K_S0
+Enddecay
+
+End

--- a/tests/dec/test_dec.py
+++ b/tests/dec/test_dec.py
@@ -101,6 +101,14 @@ def test_non_parsed_decfile():
         p.list_decay_mother_names()
 
 
+def test_decfile_defining_stable_particle():
+    p = DecFileParser(DIR / "../data/test_stable-particle.dec")
+    p.parse()
+
+    assert p.number_of_decays == 1  # The decay of K_S0, even if no decay modes are defined
+    assert p.list_decay_modes("K_S0") == []
+
+
 def test_non_existent_decay():
     p = DecFileParser(DIR / "../data/test_example_Dst.dec")
     p.parse()

--- a/tests/dec/test_dec.py
+++ b/tests/dec/test_dec.py
@@ -105,7 +105,9 @@ def test_decfile_defining_stable_particle():
     p = DecFileParser(DIR / "../data/test_stable-particle.dec")
     p.parse()
 
-    assert p.number_of_decays == 1  # The decay of K_S0, even if no decay modes are defined
+    assert (
+        p.number_of_decays == 1
+    )  # The decay of K_S0, even if no decay modes are defined
     assert p.list_decay_modes("K_S0") == []
 
 


### PR DESCRIPTION
This is trivially done in EvtGen with an empty `Decay` statement, i.e., a statement containing no decay lines/modes.