### PR TITLE
chore: a few updates suggested by sp-repo-review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
     - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,8 +12,12 @@ sphinx:
 # Include PDF and ePub
 formats: all
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-  version: 3.8
   install:
   - method: pip
     path: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,8 @@ exclude = "src/decaylanguage/(data|modeling)"
 python_version = "3.9"
 warn_unused_configs = true
 warn_unused_ignores = true
+show_error_codes = true
+enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 strict = true
 
 [[tool.mypy.overrides]]
@@ -107,6 +109,7 @@ log_cli_level = "DEBUG"
 filterwarnings = [
     "error",
 ]
+xfail_strict = true
 
 
 [tool.pylint]

--- a/src/decaylanguage/decay/decay.py
+++ b/src/decaylanguage/decay/decay.py
@@ -249,7 +249,7 @@ class DecayMode:
         self.bf = bf
         self.daughters = DaughtersDict(daughters)
 
-        self.metadata = {"model": "", "model_params": ""}
+        self.metadata: dict[str, str | None] = {"model": "", "model_params": ""}
         self.metadata.update(**info)
 
     @classmethod


### PR DESCRIPTION
<h3>General</h3>
<ul>
<li>Detected build backend: <code>hatchling.build</code></li>
<li>Detected license(s): BSD License</li>
</ul>
<h3>PyProject</h3>
<table>
<tr><th>?</th><th>Name</th><th>Description</th></tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">&#10060;</span></td>
<td>PP305</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/pytest#PP305">Specifies xfail_strict</a>
<br/>
<p><code>xfail_strict</code> should be set (probably to <code>true</code>). You can manually
specify if a check should be strict when setting each xfail.</p>

</td>
</tr>
</table>
<h3>GitHub Actions</h3>
<table>
<tr><th>?</th><th>Name</th><th>Description</th></tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">&#10060;</span></td>
<td>GH102</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/gha-basic#GH102">Auto-cancel on repeated PRs</a>
<br/>
<p>At least one workflow should auto-cancel.</p>
<pre><code class="language-yaml">concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
</code></pre>

</td>
</tr>
</table>
<h3>Pre-commit</h3>
<table>
<tr><th>?</th><th>Name</th><th>Description</th></tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">&#10060;</span></td>
<td>PC111</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/style#PC111">Uses blacken-docs</a>
<br/>
<p>Must have <code>https://github.com/adamchainz/blacken-docs</code> repo in <code>.pre-commit-config.yaml</code></p>

</td>
</tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">&#10060;</span></td>
<td>PC180</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/style#PC180">Uses prettier</a>
<br/>
<p>Must have <code>https://github.com/pre-commit/mirrors-prettier</code> repo in <code>.pre-commit-config.yaml</code></p>

</td>
</tr>
</table>
<h3>MyPy</h3>
<table>
<tr><th>?</th><th>Name</th><th>Description</th></tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">&#10060;</span></td>
<td>MY102</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/style#MY102">MyPy show error codes</a>
<br/>
<p>Must have <code>show_error_codes = true</code>. This will print helpful error codes
for users that clarify why something fails if you need to skip it.</p>

</td>
</tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">&#10060;</span></td>
<td>MY103</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/style#MY103">MyPy warn unreachable</a>
<br/>
<p>Must have <code>warn_unreachable = true</code> to pass this check. There are
occasionally false positives (often due to platform or Python version
static checks), so it's okay to ignore this check. But try it first - it
can catch real bugs too.</p>

</td>
</tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">&#10060;</span></td>
<td>MY104</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/style#MY104">MyPy enables ignore-without-code</a>
<br/>
<p>Must have <code>&quot;ignore-without-code&quot;</code> in <code>enable_error_code = [...]</code>. This
will force all skips in your project to include the error code, which
makes them more readable, and avoids skipping something unintended.</p>

</td>
</tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">&#10060;</span></td>
<td>MY105</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/style#MY105">MyPy enables redundant-expr</a>
<br/>
<p>Must have <code>&quot;redundant-expr&quot;</code> in <code>enable_error_code = [...]</code>. This helps
catch useless lines of code, like checking the same condition twice.</p>

</td>
</tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">&#10060;</span></td>
<td>MY106</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/style#MY106">MyPy enables truthy-bool</a>
<br/>
<p>Must have <code>&quot;truthy-bool&quot;</code> in <code>enable_error_code = []</code>. This catches
mistakes in using a value as truthy if it cannot be falsey.</p>

</td>
</tr>
</table>
<h3>Documentation</h3>
<table>
<tr><th>?</th><th>Name</th><th>Description</th></tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">&#10060;</span></td>
<td>RTD102</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/docs#RTD102">You have to set the RTD build image</a>
<br/>
<p>You must set <code>build: os: ubuntu-22.04</code> or similar in the
<code>.readthedocs.yaml</code> file.  Otherwise, you will get old, unsupported
versions of software for backward compatibility.
<a href="https://docs.readthedocs.io/en/stable/config-file/v2.html">Suggestion</a>:</p>
<pre><code class="language-yaml">build:
  os: ubuntu-22.04
  tools:
    python: &quot;3.11&quot;
</code></pre>

</td>
</tr>
<tr style="color: orange;">
<td><span role="img" aria-label="Skipped">&#9888;&#65039;</span></td>
<td>RTD103</td>
<td><a href="https://learn.scientific-python.org/development/guides/docs#RTD103">You have to set the RTD python version</a></td>
</tr>
</table>
