### PR TITLE
Update ci.yml to pin Python to 3.11 in pre-commit checks while pylcn gets fixed for 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: "3.11"
     - uses: pre-commit/action@v3.0.0
       with:
         extra_args: --all-files --hook-stage manual


### PR DESCRIPTION
See https://github.com/scikit-hep/decaylanguage/pull/386.