### PR TITLE
Update pylcn to 2.4.0 that supports Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.11"
+        python-version: "3.x"
     - uses: pre-commit/action@v3.0.0
       with:
         extra_args: --all-files --hook-stage manual

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
   - id: rst-inline-touching-normal
 
 - repo: https://github.com/hadialqattan/pycln
-  rev: "v2.3.0"
+  rev: "v2.4.0"
   hooks:
     - id: pycln
       args: [--all]


### PR DESCRIPTION
Reverts scikit-hep/decaylanguage#388 given that the issue with pylcn got fixed in the latest release.