### PR TITLE
EvtGen uses GeV, not the standard HEP system of units, hence MeV!

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "numpy>=1.12",
     "pandas>=0.22",
     "particle>=0.22.0",
+    "hepunits>=2.0.0",
     "plumbum>=1.7.0",
 ]
 dynamic = ["version"]

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -51,6 +51,7 @@ from lark import Lark, Token, Transformer, Tree, Visitor
 from lark.lexer import TerminalDef
 from particle import Particle
 from particle.converters import PDG2EvtGenNameMap
+from hepunits import GeV
 
 from .. import data
 from .._compat.typing import Self
@@ -460,9 +461,12 @@ class DecFileParser:
 
         Note
         ----
-        1) Particles are often defined via aliases and post-processing may be needed
+        1) Masses and widths are in GeV in EvtGen, hence the "Particle <PARTICLE> <MASS>" statement
+           needs to use GeV! A conversion to MeV may be done on the fly when information is required
+           fom the Particle package, which uses MeV, the (standard) HEP System of Units.
+        2) Particles are often defined via aliases and post-processing may be needed
            to match the mass and width to the actual particle.
-        2) The mass (width) parameter is compulsory (optional).
+        3) The mass (width) parameter is compulsory (optional).
            When not specified, the width is taken from the particle or alias.
         """
         self._check_parsing()
@@ -1629,9 +1633,12 @@ def get_particle_property_definitions(parsed_file: Tree) -> dict[str, dict[str, 
 
     Note
     ----
-    1) Particles are often defined via aliases and post-processing may be needed
+    1) Masses and widths are in GeV in EvtGen, hence the "Particle <PARTICLE> <MASS>" statement
+       needs to use GeV! A conversion to MeV may be done on the fly when information is required
+       fom the Particle package, which uses MeV, the (standard) HEP System of Units.
+    2) Particles are often defined via aliases and post-processing may be needed
        to match the mass and width to the actual particle.
-    2) The mass (width) parameter is compulsory (optional).
+    3) The mass (width) parameter is compulsory (optional).
        When not specified, the width is taken from the particle or alias.
 
     Parameters
@@ -1650,7 +1657,8 @@ def get_particle_property_definitions(parsed_file: Tree) -> dict[str, dict[str, 
         token_name: str = children[0].value
         try:
             pname: str = aliases.get(token_name, token_name) if aliases else token_name
-            return Particle.from_evtgen_name(pname).width  # type: ignore[return-value]
+            # Convert the width to GeV !
+            return Particle.from_evtgen_name(pname).width / GeV  # type: ignore[return-value]
         except Exception as err:
             raise RuntimeError(
                 f"Particle name/alias {token_name!r} not found! Check your dec file(s)!"

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -1658,7 +1658,7 @@ def get_particle_property_definitions(parsed_file: Tree) -> dict[str, dict[str, 
         try:
             pname: str = aliases.get(token_name, token_name) if aliases else token_name
             # Convert the width to GeV !
-            return Particle.from_evtgen_name(pname).width / GeV  # type: ignore[return-value]
+            return Particle.from_evtgen_name(pname).width / GeV  # type: ignore[operator]
         except Exception as err:
             raise RuntimeError(
                 f"Particle name/alias {token_name!r} not found! Check your dec file(s)!"

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -47,11 +47,11 @@ from itertools import chain, zip_longest
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
+from hepunits import GeV
 from lark import Lark, Token, Transformer, Tree, Visitor
 from lark.lexer import TerminalDef
 from particle import Particle
 from particle.converters import PDG2EvtGenNameMap
-from hepunits import GeV
 
 from .. import data
 from .._compat.typing import Self

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -463,7 +463,7 @@ class DecFileParser:
         ----
         1) Masses and widths are in GeV in EvtGen, hence the "Particle <PARTICLE> <MASS>" statement
            needs to use GeV! A conversion to MeV may be done on the fly when information is required
-           fom the Particle package, which uses MeV, the (standard) HEP System of Units.
+           from the Particle package, which uses MeV, the (standard) HEP System of Units.
         2) Particles are often defined via aliases and post-processing may be needed
            to match the mass and width to the actual particle.
         3) The mass (width) parameter is compulsory (optional).
@@ -1635,7 +1635,7 @@ def get_particle_property_definitions(parsed_file: Tree) -> dict[str, dict[str, 
     ----
     1) Masses and widths are in GeV in EvtGen, hence the "Particle <PARTICLE> <MASS>" statement
        needs to use GeV! A conversion to MeV may be done on the fly when information is required
-       fom the Particle package, which uses MeV, the (standard) HEP System of Units.
+       from the Particle package, which uses MeV, the (standard) HEP System of Units.
     2) Particles are often defined via aliases and post-processing may be needed
        to match the mass and width to the actual particle.
     3) The mass (width) parameter is compulsory (optional).

--- a/tests/data/defs-aliases-chargeconj.dec
+++ b/tests/data/defs-aliases-chargeconj.dec
@@ -288,7 +288,7 @@ IncludeDecayFactor rho0 yes
 Alias MyRho0 rho0
 Particle MyRho0 0.77
 #
-# Redefine one of the mass or width of a particle (not an alias, as in the cases above) 
+# Redefine one of the mass or width of a particle (not an alias, as in the cases above)
 # Unlike above, the width is taken from the particle since no alias is present
 Particle chi_c0 3.42
 

--- a/tests/data/defs-aliases-chargeconj.dec
+++ b/tests/data/defs-aliases-chargeconj.dec
@@ -253,6 +253,7 @@ ChargeConj Omega_cc+sig         anti-Omega_cc-sig
 
 # Specifications typically relevant when dealing with lineshapes,
 # and typically using particle name aliases
+# Important note on values below: masses and widths are in GeV in EvtGen!
 #
 Alias MyK*0 K*0
 Particle       MyK*0  0.892  0.051  # To set a particle mass and width
@@ -280,9 +281,16 @@ LSNONRELBW rho0
 BlattWeisskopf rho0 3.0
 IncludeBirthFactor rho0 no
 IncludeDecayFactor rho0 yes
-# Redefined particles only need to specify the mass, and the width is optional
+#
+# Redefined particles only need to specify the mass, and the width is optional,
+# in which case the value is taken from the alias
+# and will correspond to the nominal mass as provided by the Particle package
 Alias MyRho0 rho0
-Particle MyRho0 0.8
+Particle MyRho0 0.77
+#
+# Redefine one of the mass or width of a particle (not an alias, as in the cases above) 
+# Unlike above, the width is taken from the particle since no alias is present
+Particle chi_c0 3.42
 
 # Pythia 8 parameter modifications
 # (Very important that there are no blank spaces in the parameter string!)

--- a/tests/dec/test_dec.py
+++ b/tests/dec/test_dec.py
@@ -197,7 +197,8 @@ def test_particle_property_definitions():
         "MyK*0": {"mass": 0.892, "width": 0.051},
         "MyPhi": {"mass": 1.02, "width": 0.004},
         "rho0": {"mass": 0.8, "width": 0.2},
-        "MyRho0": {"mass": 0.8, "width": 147.4},
+        "MyRho0": {"mass": 0.77, "width": 0.1474},
+        "chi_c0": {"mass": 3.42, "width": 0.0107},
     }
 
 


### PR DESCRIPTION
As such, there was a bug whe an EvtGen `Particle` statement would not define the optional width, which was taken from the particle or alias and hence returned in MeV.