### PR TITLE
ci: bump setup-uv to maintained tag scheme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/setup-python@v6
       with:
         python-version: "3.x"
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@v8.0.0
     - uses: pre-commit/action@v3.0.1
       with:
         extra_args: --all-files --hook-stage manual
@@ -51,7 +51,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
 
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@v8.0.0
 
     - name: Install package
       run: uv pip install --system -e. --group=test
@@ -84,7 +84,7 @@ jobs:
       with:
         python-version: "3.x"
 
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@v8.0.0
 
     - name: Install dot
       run: sudo apt-get install graphviz


### PR DESCRIPTION
The old vX tags have been dropped to (force) (usually) better security practices. Dependabot will not update, however, leaving this v7 tag forever. Manually updating now.

See https://github.com/astral-sh/setup-uv/issues/830

Committed via https://github.com/asottile/all-repos