### PR TITLE
fix(utils): fix split() trailing-comma bug, single-pass filter_lines, remove dead code, unbounded cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   - Migrated `ModelDecay` and `AmplitudeChain` from old-style `@attr.s`/`attr.ib` to modern `@attrs.define`/`attrs.field`.
   - Removed dead `graphviz` import guard in `decay.py` (graphviz is a hard dependency).
   - Various fixes and minor improvements.
+* Utilities:
+  - Fixed a bug in `split()` where a trailing comma was not handled correctly (e.g. `split("a,")` returned `["a,"]` instead of `["a", ""]`); rewrote as a single linear scan to eliminate O(n²) repeated string slicing.
+  - Fixed `filter_lines()` to collect matched lines and residuals in a single pass instead of running the regex twice per line.
+  - Removed dead code in `particleutils._from_group_dict_list`: the `prime` group check could never fire as the `_getname` regex has no `prime` capture group.
+  - Bumped `lru_cache(maxsize=64)` to `lru_cache(maxsize=None)` on the pure string-mapping `charge_conjugate_name` function.
 * Dependencies:
   - Moved `numpy`, `pandas` and `plumbum` into an optional `decaylanguage[modeling]` extra; they are only needed by the `modeling` subpackage and the command-line interface. Core `.dec` parsing and decay-chain functionality no longer pull them in.
 * CI and tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,13 @@
 * Parsing of decay files (aka .dec files):
   - Various improvements to the code, for more robustness.
   - A couple of fixes related to the decay file parser.
-* Modeling subsystem (`modeling/`):
+* Modeling submodule (`modeling/`):
   - Migrated `ModelDecay` and `AmplitudeChain` from old-style `@attr.s`/`attr.ib` to modern `@attrs.define`/`attrs.field`.
   - Removed dead `graphviz` import guard in `decay.py` (graphviz is a hard dependency).
   - Various fixes and minor improvements.
-* Utilities:
-  - Fixed a bug in `split()` where a trailing comma was not handled correctly (e.g. `split("a,")` returned `["a,"]` instead of `["a", ""]`); rewrote as a single linear scan to eliminate O(n²) repeated string slicing.
+* Utilities submodule:
+  - Fixed a bug in `split()` where a trailing comma was not handled correctly (e.g. `split("a,")` returned `["a,"]` instead of `["a", ""]`).
   - Fixed `filter_lines()` to collect matched lines and residuals in a single pass instead of running the regex twice per line.
-  - Removed dead code in `particleutils._from_group_dict_list`: the `prime` group check could never fire as the `_getname` regex has no `prime` capture group.
-  - Bumped `lru_cache(maxsize=64)` to `lru_cache(maxsize=None)` on the pure string-mapping `charge_conjugate_name` function.
 * Dependencies:
   - Moved `numpy`, `pandas` and `plumbum` into an optional `decaylanguage[modeling]` extra; they are only needed by the `modeling` subpackage and the command-line interface. Core `.dec` parsing and decay-chain functionality no longer pull them in.
 * CI and tests:

--- a/src/decaylanguage/utils/particleutils.py
+++ b/src/decaylanguage/utils/particleutils.py
@@ -19,7 +19,7 @@ from particle.converters import (
 from particle.exceptions import MatchingIDNotFound
 from particle.particle.enums import Charge_mapping
 
-cacher = lru_cache(maxsize=64)
+cacher = lru_cache(maxsize=None)
 
 
 @cacher
@@ -139,9 +139,6 @@ def _from_group_dict_list(mat: dict[str, Any]) -> list[Particle]:
         name += f"({mat['family']})"
     if mat["state"]:
         name += f"({mat['state']})"
-
-    if mat.get("prime"):
-        name += "'"
 
     if mat["star"]:
         name += "*"

--- a/src/decaylanguage/utils/utilities.py
+++ b/src/decaylanguage/utils/utilities.py
@@ -31,23 +31,19 @@ def split(x: str) -> list[str]:
     this, that { that { this, that } }
     would only break on the first comma, since the second is in a {} list
     """
-
-    c = 0
-    i = 0
+    depth = 0
+    start = 0
     out = []
-    while len(x) > 0:
-        if i + 1 == len(x):
-            out.append(x[: i + 1])
-            return out
-        if x[i] == "," and c == 0:
-            out.append(x[:i])
-            x = x[i + 1 :]
-            i = -1
-        elif x[i] == "{":
-            c += 1
-        elif x[i] == "}":
-            c -= 1
-        i += 1
+    for i, ch in enumerate(x):
+        if ch == "," and depth == 0:
+            out.append(x[start:i])
+            start = i + 1
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+    if x:
+        out.append(x[start:])
     return out
 
 
@@ -57,9 +53,14 @@ def filter_lines(
     """
     Filter out lines into new variable if they match a regular expression
     """
-    matches = (matcher.match(ln) for ln in inp)
-    output = [match.groupdict() for match in matches if match is not None]
-    new_inp = [ln for ln in inp if matcher.match(ln) is None]
+    output = []
+    new_inp = []
+    for ln in inp:
+        m = matcher.match(ln)
+        if m is not None:
+            output.append(m.groupdict())
+        else:
+            new_inp.append(ln)
     return output, new_inp
 
 

--- a/tests/utils/test_utilities.py
+++ b/tests/utils/test_utilities.py
@@ -5,10 +5,61 @@
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from decaylanguage import DecayChain, DecayMode
-from decaylanguage.utils import DescriptorFormat
+from decaylanguage.utils import DescriptorFormat, filter_lines, split
+
+
+@pytest.mark.parametrize(
+    ("inp", "expected"),
+    [
+        ("a,b", ["a", "b"]),
+        ("a,b,c", ["a", "b", "c"]),
+        ("a", ["a"]),
+        ("", []),
+        # trailing comma: previously returned ["a,"] (bug)
+        ("a,", ["a", ""]),
+        # leading comma
+        (",a", ["", "a"]),
+        # bare comma
+        (",", ["", ""]),
+        # nesting: comma inside {} does not split
+        ("a{b,c},d", ["a{b,c}", "d"]),
+        # deep nesting
+        ("a{b{c,d},e},f", ["a{b{c,d},e}", "f"]),
+        # comma only inside braces — no top-level split
+        ("{a,b}", ["{a,b}"]),
+    ],
+)
+def test_split(inp: str, expected: list[str]) -> None:
+    assert split(inp) == expected
+
+
+@pytest.mark.parametrize(
+    ("lines", "matched_keys", "remaining"),
+    [
+        (
+            ["foo 1", "bar 2", "foo 3", "baz"],
+            [{"word": "foo", "num": "1"}, {"word": "foo", "num": "3"}],
+            ["bar 2", "baz"],
+        ),
+        ([], [], []),
+        (["no_match"], [], ["no_match"]),
+    ],
+)
+def test_filter_lines(
+    lines: list[str],
+    matched_keys: list[dict[str, str]],
+    remaining: list[str],
+) -> None:
+    pattern = re.compile(r"^(?P<word>foo) (?P<num>\d+)$")
+    output, new_inp = filter_lines(pattern, lines)
+    assert output == matched_keys
+    assert new_inp == remaining
+
 
 dm1 = DecayMode(0.6770, "D0 pi+")  # D*+
 dm2 = DecayMode(0.0124, "K_S0 pi0")  # D0


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #581

## Summary

- **`split()` trailing-comma bug**: the `i+1==len(x)` early-exit ran before the comma check, so `split("a,")` returned `["a,"]` instead of `["a", ""]`. Rewrote as a single linear scan tracking bracket depth, eliminating the O(n²) repeated `x = x[i+1:]` string slicing.
- **`filter_lines()` double-match**: collected matched lines and residuals in one pass instead of calling `matcher.match()` twice per line.
- **Dead code in `_from_group_dict_list`**: removed `mat.get("prime")` branch — the `_getname` regex has no `prime` capture group so the condition could never be true.
- **`lru_cache` sizing**: bumped `maxsize=64` to `maxsize=None` on `charge_conjugate_name`, which is a pure `str→str` mapping called with hundreds of distinct species in typical decay files.

## Test plan

- [ ] Added parametrised tests for `split()` covering nesting, trailing comma, leading comma, bare comma, empty string, and deeply nested brackets.
- [ ] Added parametrised tests for `filter_lines()` covering normal matches, empty input, and no-match input.
- [ ] `uv run pytest` — 312 passed, 1 skipped (pre-existing unconditional skip).
- [ ] `prek -a --quiet` — clean.