### PR TITLE
fix(dec): fix several bugs in the .dec file parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+* Parsing of decay files (aka .dec files):
+  - Fixed a crash when a `ModelAlias` is used in more than one decay, caused by sharing the same parse-tree tokens across decays (the model-parameter substitution mutated them in place).
+  - Fixed `DecFileParser.print_decay_modes(ascending=...)`, which previously ignored the flag and always sorted descending; `scale` now always normalizes to the largest branching fraction.
+  - Made `DecFileParser.from_string` filter intermediate `End` lines like the file-based constructor, so identical content parses the same way either way.
+  - `ChargeConjugateReplacement` no longer mutates the caller's `charge_conj_defs` dict and no longer caches `ChargeConj(...)` failure sentinels.
+  - `get_lineshape_settings` no longer masks its own specific "redefined"/structure diagnostics behind a generic error.
+  - `get_branching_fraction` now catches the exception types actually raised by malformed input.
+  - `load_additional_decay_models` now warns when called after the grammar is loaded and stores a materialized container instead of a one-shot iterator.
+  - Fixed a missing f-string prefix in a `print_decay_modes` error message.
+
 * CI and tests:
   - Several improvements, enhancements and clean_ups.
   - Removed dead `filterwarnings` ignore for PyArrow/pandas deprecation (pandas >=2.2.2 no longer emits it).

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -116,15 +116,7 @@ class DecFileParser:
                     raise FileNotFoundError(f"{str(filename)!r}!")
 
                 with filename.open(encoding="utf_8") as file:
-                    for line in file:
-                        # We need to strip the unicode byte ordering if present before checking for *
-                        beg = line.lstrip("\ufeff").lstrip()
-                        # Make sure one discards all lines "End"
-                        # in intermediate files, to avoid a parsing error
-                        if not (
-                            beg.startswith("End") and not beg.startswith("Enddecay")
-                        ):
-                            stream.write(line)
+                    stream.write(self._filter_lines(file))
                     stream.write("\n")
 
             stream.seek(0)
@@ -146,6 +138,21 @@ class DecFileParser:
         # By default, consider charge-conjugate decays when parsing
         self._include_ccdecays = True
 
+    @staticmethod
+    def _filter_lines(lines: Iterable[str]) -> str:
+        """
+        Filter out intermediate "End" lines (but not "Enddecay" lines),
+        which are present in intermediate decay files and would otherwise
+        cause a parsing error. The unicode byte-order mark is stripped before
+        the check, if present.
+        """
+        stream = StringIO()
+        for line in lines:
+            beg = line.lstrip("﻿").lstrip()
+            if not (beg.startswith("End") and not beg.startswith("Enddecay")):
+                stream.write(line)
+        return stream.getvalue()
+
     @classmethod
     def from_string(cls, filecontent: str) -> Self:
         """
@@ -156,12 +163,11 @@ class DecFileParser:
         filecontent: str
             Input .dec decay file content.
         """
-        stream = StringIO(filecontent)
-        stream.seek(0)
-
         _cls = cls()
         _cls._dec_file_names = ["<dec file input as a string>"]
-        _cls._dec_file = stream.read()
+        # Apply the same intermediate-"End"-line filtering as the file-based
+        # constructor, so identical content parses the same way either way.
+        _cls._dec_file = _cls._filter_lines(StringIO(filecontent))
 
         return _cls
 
@@ -209,9 +215,11 @@ class DecFileParser:
 
         # At last, find all particle decays defined in the .dec decay file ...
         self._find_parsed_decays()
-        # Replace model aliases with the actual models and model parameters. Deepcopy to avoid modification of dict by
-        # DecayModelParamValueReplacement Visitor.
-        dict_model_aliases = copy.deepcopy(self._dict_raw_model_aliases())
+        # Replace model aliases with the actual models and model parameters.
+        # DecayModelAliasReplacement deep-copies each subtree at replacement
+        # time, so the in-place mutations later done by
+        # DecayModelParamValueReplacement do not leak across decay trees.
+        dict_model_aliases = self._dict_raw_model_aliases()
         self._parsed_decays = [
             DecayModelAliasReplacement(model_alias_defs=dict_model_aliases).transform(
                 tree
@@ -277,13 +285,27 @@ class DecFileParser:
         models: str
             names of the additional decay models to be considered.
         """
+        # The additional models are injected into the grammar terminals when the
+        # grammar is loaded (see ``_generate_edit_terminals_callback``). Once the
+        # grammar has been loaded, calling this method has no effect, so warn the
+        # user that they called it too late.
+        if self.grammar_loaded:
+            warnings.warn(
+                "The grammar has already been loaded; additional decay models "
+                "passed to ``load_additional_decay_models`` will be ignored. "
+                "Call this method before ``grammar``/``parse``.",
+                stacklevel=2,
+            )
 
         if self._additional_decay_models is None:
-            self._additional_decay_models = models
+            self._additional_decay_models = list(models)
         else:
-            self._additional_decay_models = chain.from_iterable(
-                (self._additional_decay_models, models)
-            )
+            # Store a materialized container, not a one-shot iterator that would
+            # be exhausted the first time the grammar callback consumes it.
+            self._additional_decay_models = [
+                *self._additional_decay_models,
+                *models,
+            ]
 
     def _load_grammar(
         self,
@@ -927,7 +949,7 @@ All but the first occurrence will be discarded/removed ...""".format(
                 )
             if not 0.0 < scale <= 1.0:
                 raise RuntimeError(
-                    "A branching fraction must be in the range ]0, 1]! You set scale = {scale}."
+                    f"A branching fraction must be in the range ]0, 1]! You set scale = {scale}."
                 )
 
         if pdg_name:
@@ -947,16 +969,16 @@ All but the first occurrence will be discarded/removed ...""".format(
             max_length = max(len(decay_chain), max_length)
             ls.append((dmdict["bf"], decay_chain, dmdict["model"], model_params))
 
-        # Sort decays by decreasing BF
-        ls = sorted(ls, key=lambda x: -x[0])
+        # Sort decays by branching fraction, ascending or descending as requested
+        ls = sorted(ls, key=lambda x: x[0], reverse=not ascending)
 
         norm: float = 1.0
         if normalize:
             norm = sum(bf for bf, _, _, _ in ls)
         elif scale is not None:
-            # Get the largest branching fraction
-            i = -1 if ascending else 0
-            norm = ls[i][0] / scale
+            # Normalize relative to the largest branching fraction,
+            # independently of the chosen sort order
+            norm = max(bf for bf, _, _, _ in ls) / scale
 
         max_length_string = str(max_length + 2)
         for bf, fs, model, model_params in ls:
@@ -1165,7 +1187,11 @@ class DecayModelAliasReplacement(Transformer):  # type: ignore[misc]
                 f"Decay model or ModelAlias {t.value} is not defined. Please load the decay model with "
                 "``load_additional_decay_models`` or define a ModelAlias in the decayfile."
             )
-        return self.define_defs[t.value]
+        # Deep-copy so that every use of a model alias gets its own Token/Tree
+        # instances. Otherwise all decay trees using the alias would share the
+        # same children, and the in-place mutations done by
+        # DecayModelParamValueReplacement would corrupt them across trees.
+        return copy.deepcopy(self.define_defs[t.value])
 
     def model(self, treelist: list[Tree]) -> Tree:
         """
@@ -1281,7 +1307,9 @@ class ChargeConjugateReplacement(Visitor):  # type: ignore[misc]
     """
 
     def __init__(self, charge_conj_defs: dict[str, str] | None = None) -> None:
-        self.charge_conj_defs = charge_conj_defs or {}
+        # Copy the user-provided dict, since it is used internally as a cache.
+        # Mutating the caller's dict would silently pollute it.
+        self.charge_conj_defs = dict(charge_conj_defs) if charge_conj_defs else {}
 
     def particle(self, tree: Tree) -> None:
         """
@@ -1290,7 +1318,11 @@ class ChargeConjugateReplacement(Visitor):  # type: ignore[misc]
         assert tree.data == "particle"
         pname = tree.children[0].value
         ccpname = find_charge_conjugate_match(pname, self.charge_conj_defs)
-        self.charge_conj_defs[pname] = ccpname
+        # Do not cache failure sentinels of the form 'ChargeConj(<name>)':
+        # they are not genuine matches and, if cached, the reverse lookup in
+        # find_charge_conjugate_match could spuriously match against them.
+        if not ccpname.startswith("ChargeConj("):
+            self.charge_conj_defs[pname] = ccpname
         tree.children[0].value = ccpname
 
 
@@ -1352,7 +1384,7 @@ def get_branching_fraction(decay_mode: Tree) -> float:
     # and tree.children[0].children[0].value is the BF stored as a str
     try:  # the branching fraction value as a float
         return float(decay_mode.children[0].children[0].value)
-    except RuntimeError as e:
+    except (AttributeError, IndexError, ValueError) as e:
         raise RuntimeError(
             "'decayline' Tree does not seem to have the usual structure. Check it."
         ) from e
@@ -1845,7 +1877,7 @@ def get_lineshape_settings(
             else:
                 raise RuntimeError(
                     "Input parsed file does not seem to have the expected structure for the lineshape definitions."
-                ) from None
+                )
 
         # Blatt-Weisskopf barrier factor for a lineshape
         for tree in parsed_file.find_data("setlsbw"):
@@ -1854,7 +1886,7 @@ def get_lineshape_settings(
                 if "BlattWeisskopf" in d[particle_or_alias]:
                     raise RuntimeError(
                         f"The Blatt-Weisskopf barrier factor for particle/alias {particle_or_alias} seems to be redefined."
-                    ) from None
+                    )
                 d[particle_or_alias]["BlattWeisskopf"] = float(tree.children[1].value)
             else:
                 d[particle_or_alias] = {"BlattWeisskopf": float(tree.children[1].value)}
@@ -1866,7 +1898,7 @@ def get_lineshape_settings(
                 if tree.children[0].value in d[particle_or_alias]:
                     raise RuntimeError(
                         f"The upper/lower mass cut on the lineshape for particle/alias {particle_or_alias} seems to be redefined."
-                    ) from None
+                    )
                 d[particle_or_alias][f"{tree.children[0].value}"] = float(
                     tree.children[2].value
                 )
@@ -1882,7 +1914,7 @@ def get_lineshape_settings(
                 if tree.children[0].value in d[particle_or_alias]:
                     raise RuntimeError(
                         f"The birth/decay momentum factor for particle/alias {particle_or_alias} seems to be redefined."
-                    ) from None
+                    )
                 d[particle_or_alias][f"{tree.children[0].value}"] = _str_to_bool(
                     tree.children[2].value
                 )
@@ -1893,6 +1925,10 @@ def get_lineshape_settings(
 
         return d
 
+    except RuntimeError:
+        # Let the specific, informative "redefined"/structure diagnostics
+        # raised above propagate unchanged.
+        raise
     except Exception as err:
         raise RuntimeError(
             "Input parsed file does not seem to have the expected structure."

--- a/tests/dec/test_dec.py
+++ b/tests/dec/test_dec.py
@@ -657,6 +657,67 @@ def test_print_decay_modes_options():
     del old_stdout, tmp_stdout
 
 
+def _bf_column(output):
+    """Extract the leading branching-fraction column from print_decay_modes output."""
+    return [float(line.split()[0]) for line in output.strip().splitlines()]
+
+
+def test_print_decay_modes_ascending(capsys):
+    p = DecFileParser(DIR / "../data/test_example_Dst.dec")
+    p.parse()
+
+    p.print_decay_modes("D*+")
+    descending = _bf_column(capsys.readouterr().out)
+
+    p.print_decay_modes("D*+", ascending=True)
+    ascending = _bf_column(capsys.readouterr().out)
+
+    # Default is descending; ascending=True flips the order
+    assert descending == sorted(descending, reverse=True)
+    assert ascending == sorted(ascending)
+    assert ascending == descending[::-1]
+
+
+def test_print_decay_modes_scale_uses_largest_bf(capsys):
+    p = DecFileParser(DIR / "../data/test_example_Dst.dec")
+    p.parse()
+
+    # Regardless of sort order, scaling sets the largest BF to `scale`.
+    p.print_decay_modes("D*+", scale=0.5)
+    desc = _bf_column(capsys.readouterr().out)
+
+    p.print_decay_modes("D*+", scale=0.5, ascending=True)
+    asc = _bf_column(capsys.readouterr().out)
+
+    assert max(desc) == pytest.approx(0.5)
+    assert max(asc) == pytest.approx(0.5)
+
+
+def test_load_additional_decay_models_too_late():
+    p = DecFileParser(DIR / "../data/test_custom_decay_model.dec")
+    # Force the grammar to load.
+    assert p.grammar() is not None
+    assert p.grammar_loaded
+
+    with pytest.warns(UserWarning, match="already been loaded"):
+        p.load_additional_decay_models("CUSTOM_MODEL1")
+
+
+def test_load_additional_decay_models_repeated_calls():
+    # Regression test: the second call used to store a one-shot itertools.chain
+    # iterator that was exhausted the first time the grammar callback consumed
+    # it, so the grammar silently lost the additional models.
+    p = DecFileParser(DIR / "../data/test_custom_decay_model.dec")
+    p.load_additional_decay_models("CUSTOM_MODEL1")
+    p.load_additional_decay_models("CUSTOM_MODEL2")
+
+    assert p.grammar() is not None
+    p.parse()
+
+    assert get_model_name(p._parsed_decays[0].children[1]) == "CUSTOM_MODEL1"
+    assert get_model_name(p._parsed_decays[0].children[2]) == "CUSTOM_MODEL2"
+
+
 def test_build_decay_chains():
     p = DecFileParser(DIR / "../data/test_example_Dst.dec")
     p.parse()

--- a/tests/dec/test_issues.py
+++ b/tests/dec/test_issues.py
@@ -8,9 +8,13 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from lark import UnexpectedToken
+from lark import Token, Tree, UnexpectedToken
 
-from decaylanguage.dec.dec import DecFileParser
+from decaylanguage.dec.dec import (
+    ChargeConjugateReplacement,
+    DecFileParser,
+    get_branching_fraction,
+)
 
 DIR = Path(__file__).parent.resolve()
 
@@ -19,3 +23,76 @@ def test_issue_90():
     p = DecFileParser(DIR / "../data/test_issue90.dec")
     with pytest.raises(UnexpectedToken):
         p.parse()
+
+
+def test_model_alias_shared_subtree():
+    # Regression test: a ModelAlias used in more than one decay tree used to
+    # share the same Token objects across trees, so the in-place float
+    # substitution done while parsing crashed on the second tree with
+    # "TypeError: 'float' object is not subscriptable".
+    s = """
+Define dm 0.507e12
+Alias myB B0
+ModelAlias myVSS_BMIX VSS_BMIX dm;
+Decay B0
+1.0 myB myB myVSS_BMIX;
+Enddecay
+Decay anti-B0
+1.0 myB myB myVSS_BMIX;
+Enddecay
+"""
+    p = DecFileParser.from_string(s)
+    p.parse()  # used to raise TypeError
+
+    # Both trees should have the value substituted independently.
+    for mother in ("B0", "anti-B0"):
+        modes = p._find_decay_modes(mother)
+        assert modes
+
+
+def test_from_string_filters_intermediate_end_lines():
+    # Regression test: from_string must apply the same intermediate-"End"-line
+    # filtering as the file-based constructor, so identical content parses the
+    # same way either way.
+    s = """
+Decay B0
+1.0 pi+ pi- PHSP;
+Enddecay
+End
+Decay anti-B0
+1.0 pi+ pi- PHSP;
+Enddecay
+"""
+    p = DecFileParser.from_string(s)
+    p.parse()  # the stray "End" line used to break string parsing
+    assert "B0" in p.list_decay_mother_names()
+
+
+def test_charge_conjugate_replacement_does_not_mutate_caller_dict():
+    # Regression test: ChargeConjugateReplacement used the caller's dict as a
+    # cache, silently polluting it (including failure sentinels of the form
+    # 'ChargeConj(<name>)').
+    user_dict = {"FancyParticle": "FancyAntiParticle"}
+    snapshot = dict(user_dict)
+
+    t = Tree(
+        "decay",
+        [
+            Tree("particle", [Token("LABEL", "SomeUnknownParticle")]),
+        ],
+    )
+    ChargeConjugateReplacement(charge_conj_defs=user_dict).visit(t)
+
+    # The user's dict must be untouched ...
+    assert user_dict == snapshot
+    # ... and failure sentinels must not have been cached anywhere.
+    assert all(not v.startswith("ChargeConj(") for v in user_dict.values())
+
+
+def test_get_branching_fraction_malformed_input():
+    # Regression test: malformed input raises AttributeError/IndexError/
+    # ValueError, which used to escape the (dead) "except RuntimeError" and was
+    # never re-raised as the friendly RuntimeError.
+    bad = Tree("decayline", [Tree("value", [Token("SIGNED_NUMBER", "not-a-number")])])
+    with pytest.raises(RuntimeError):
+        get_branching_fraction(bad)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #581

This PR fixes a set of bugs in the `dec/` subsystem (`src/decaylanguage/dec/dec.py`), with regression tests for each.

## Fixes

1. **ModelAlias shared-subtree crash (high).** A `ModelAlias` used in more than one decay returned the same children list for every use, so all decay trees shared the same `Token` objects. `DecayModelParamValueReplacement` then mutated those tokens in place once per containing tree, and the second visit crashed with `TypeError: 'float' object is not subscriptable`. Fixed by deep-copying each subtree at replacement time inside `DecayModelAliasReplacement._replacement`, and dropping the now-redundant outer `deepcopy` in `parse`.

2. **`print_decay_modes(ascending=...)` broken (medium).** The method always sorted descending and ignored `ascending`; the `scale` normalization used `i = -1 if ascending else 0`, which combined with the descending sort picked the *smallest* BF. Now sorts according to `ascending` and always normalizes `scale` by the actual largest BF.

3. **Missing f-string prefix (low).** The `scale` out-of-range error message lacked the `f` prefix, so `{scale}` was printed literally.

4. **`from_string` vs `__init__` inconsistency (low).** `__init__` strips intermediate lines starting with `End` (but not `Enddecay`); `from_string` did not, so identical content could parse from a file but fail from a string. Extracted the filtering into a shared `_filter_lines` helper used by both.

5. **`ChargeConjugateReplacement` mutated the caller's dict (low).** The user-provided `charge_conj_defs` dict was used as a cache and silently polluted, including caching `ChargeConj(...)` failure sentinels that the reverse lookup could then match. Now copies the dict internally and does not cache failure sentinels.

6. **`get_lineshape_settings` masked its own diagnostics (low).** The specific "redefined"/structure `RuntimeError`s raised inside the `try` were swallowed by the function's blanket `except Exception` and re-wrapped generically; the inner `from None` also contradicted the outer `from err`. The specific `RuntimeError`s now propagate, and the contradictory `raise ... from` usage was cleaned up.

7. **Dead `except RuntimeError` in `get_branching_fraction` (low).** Malformed input raises `AttributeError`/`IndexError`/`ValueError`, never `RuntimeError`, so the friendly re-raise never fired. Now catches the actual exception types.

8. **`load_additional_decay_models` (low).** It was a silent no-op if the grammar was already loaded, and stored a one-shot `itertools.chain` iterator that was exhausted on first materialization. Now warns when called after the grammar is loaded and stores a materialized list.

## Testing

- `uv run pytest`: 307 passed, 1 skipped.
- `prek -a --quiet`: clean.
- Added regression tests in `tests/dec/test_issues.py` and `tests/dec/test_dec.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)