### PR TITLE
chore: fix packaging config, CI, and pre-commit housekeeping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
       with:
         python-version: "3.x"
     - uses: astral-sh/setup-uv@v8.1.0
-    - uses: pre-commit/action@v3.0.1
+    - uses: j178/prek-action@v2
       with:
-        extra_args: --all-files --hook-stage manual
+        extra-args: --all-files --hook-stage manual
     - name: PyLint
       run: uvx nox -s pylint -- --output-format=github
 
@@ -44,6 +44,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
 
     - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
@@ -54,11 +56,7 @@ jobs:
     - uses: astral-sh/setup-uv@v8.1.0
 
     - name: Install package
-      run: uv pip install --system -e. --group=test
-
-    - name: Pytest
-      if: runner.os == 'Linux'
-      run: python -m pip install pytest-github-actions-annotate-failures
+      run: uv pip install --system -e. --group=test pytest-github-actions-annotate-failures
 
     - name: Test package
       run: python -m pytest ./tests --cov=src/decaylanguage --cov-report=xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,6 @@ repos:
   - id: check-case-conflict
   - id: check-symlinks
   - id: check-yaml
-  - id: requirements-txt-fixer
   - id: debug-statements
   - id: end-of-file-fixer
 
@@ -30,7 +29,7 @@ repos:
   hooks:
   - id: mypy
     files: '^src/decaylanguage/(decay|dec|utils)/'
-    additional_dependencies: [attrs, particle, importlib_resources, numpy]
+    additional_dependencies: [particle, hepunits]
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,9 @@
 ## Unreleased
 
 * CI and tests:
-  - Fixed over-escaped `--doctest-glob=\\*.rst` pattern in pytest config (was `\*.rst`, never matched).
+  - Several improvements, enhancements and clean_ups.
   - Removed dead `filterwarnings` ignore for PyArrow/pandas deprecation (pandas >=2.2.2 no longer emits it).
-  - Aligned `[tool.pylint] py-version` with `requires-python` (`"3.10"`).
-  - Fixed `check-wheel-contents` invocation in nox `build` session to pass `dist/` directory instead of a fragile glob.
   - Trimmed mypy pre-commit hook's `additional_dependencies` to only what the covered code actually imports (`particle`, `hepunits`).
-  - Removed dead `requirements-txt-fixer` pre-commit hook (no requirements*.txt files exist).
-  - Replaced deprecated `pre-commit/action` with `j178/prek-action@v2` in the lint CI job.
-  - Added `fetch-depth: 0` to the `checks` job for consistent hatch-vcs version stamping.
-  - Folded `pytest-github-actions-annotate-failures` into the main uv install step.
   - Raised minimum dependency floors to oldest versions with cp310 wheels: `numpy>=1.21.6`, `pandas>=1.4`.
 
 ## Version 0.20.4 (2026-04-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+* CI and tests:
+  - Fixed over-escaped `--doctest-glob=\\*.rst` pattern in pytest config (was `\*.rst`, never matched).
+  - Removed dead `filterwarnings` ignore for PyArrow/pandas deprecation (pandas >=2.2.2 no longer emits it).
+  - Aligned `[tool.pylint] py-version` with `requires-python` (`"3.10"`).
+  - Fixed `check-wheel-contents` invocation in nox `build` session to pass `dist/` directory instead of a fragile glob.
+  - Trimmed mypy pre-commit hook's `additional_dependencies` to only what the covered code actually imports (`particle`, `hepunits`).
+  - Removed dead `requirements-txt-fixer` pre-commit hook (no requirements*.txt files exist).
+  - Replaced deprecated `pre-commit/action` with `j178/prek-action@v2` in the lint CI job.
+  - Added `fetch-depth: 0` to the `checks` job for consistent hatch-vcs version stamping.
+  - Folded `pytest-github-actions-annotate-failures` into the main uv install step.
+  - Raised minimum dependency floors to oldest versions with cp310 wheels: `numpy>=1.21.6`, `pandas>=1.4`.
+
 ## Version 0.20.4 (2026-04-16)
 
 * Parsing of decay files (aka .dec files):

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import nox
 
 nox.needs_version = ">=2025.02.09"
@@ -51,6 +49,4 @@ def build(session):
     session.install("build", "twine", "check-wheel-contents")
     session.run("python", "-m", "build")
     session.run("twine", "check", "--strict", "dist/*")
-    session.run(
-        "check-wheel-contents", str(*Path("dist").glob("*.whl")), "--ignore=W002"
-    )
+    session.run("check-wheel-contents", "dist/", "--ignore=W002")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ dependencies = [
     "attrs>=19.2",
     "graphviz>=0.12.0",
     "lark>=1.0.0",
-    "numpy>=1.9.3",
-    "pandas>=1",
+    "numpy>=1.21.6",
+    "pandas>=1.4",
     "particle>=0.26.0",
     "hepunits>=2.4.0",
     "plumbum>=1.7.0",
@@ -105,7 +105,7 @@ testpaths = ["tests"]
 addopts = [
     "-ra",
     "--doctest-modules",
-    "--doctest-glob=\\*.rst",
+    "--doctest-glob=*.rst",
     "--strict-markers",
     "--strict-config",
 ]
@@ -115,13 +115,12 @@ markers = [
 log_level = "DEBUG"
 filterwarnings = [
     "error",
-    '''ignore:\s*Pyarrow will become a required dependency of pandas:DeprecationWarning''',
 ]
 xfail_strict = true
 
 
 [tool.pylint]
-py-version = "3.12"
+py-version = "3.10"
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"
 jobs = "0"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #581.

## Summary

Ten targeted fixes to pyproject.toml, noxfile.py, .pre-commit-config.yaml, and .github/workflows/ci.yml — no functional changes to library code.

- **pyproject.toml** — corrected over-escaped `--doctest-glob=\\*.rst` (was literal `\*.rst`, fnmatch never matches it); removed dead pandas/PyArrow `filterwarnings` ignore (only existed in pandas 2.2.0/2.2.1, lockfile has 2.3.3+); aligned `[tool.pylint] py-version` with `requires-python` (`"3.10"` instead of `"3.12"`); raised `numpy>=1.21.6` and `pandas>=1.4` to the oldest versions that ship cp310 wheels on PyPI (verified against pypi.org/pypi/\*/json).
- **noxfile.py** — replaced `str(*Path("dist").glob("*.whl"))` (silent empty string / TypeError with multiple wheels) with `"dist/"` — `check-wheel-contents` accepts a directory directly. The now-unused `Path` import was auto-removed by ruff.
- **.pre-commit-config.yaml** — reduced mypy hook's `additional_dependencies` from `[attrs, particle, importlib_resources, numpy]` to `[particle, hepunits]` (only packages directly imported in `dec/`, `decay/`, `utils/` covered by the hook); removed the dead `requirements-txt-fixer` hook (no `requirements*.txt` files exist).
- **.github/workflows/ci.yml** — replaced maintenance-mode `pre-commit/action@v3.0.1` with `j178/prek-action@v2` (project already standardised on prek per noxfile and CLAUDE.md); added `fetch-depth: 0` to the `checks` job so hatch-vcs stamps the same version as the other jobs; folded the separate `python -m pip install pytest-github-actions-annotate-failures` step into the main `uv pip install` line (removes the mislabelled "Pytest" step that only installed, never tested).

## Validation

- `uv run pytest`: 299 passed, 1 skipped (no regressions from filterwarnings removal or glob fix)
- `prek -a --quiet`: clean (ruff auto-removed unused `Path` import in noxfile.py)
- `pylint src/`: 10.00/10 (py-version 3.10 is clean)
- `actionlint` / `zizmor`: actionlint not available via uvx; zizmor findings are all pre-existing unpinned-action warnings unrelated to this PR

## Open question: `decaylanguage[modeling]` extra

The `modeling/` sub-package pulls in `pandas`, `numpy`, and `plumbum`, which are currently unconditional runtime dependencies even for users who only need `.dec` parsing or the universal decay-chain representation. Splitting them into an optional `decaylanguage[modeling]` extra would reduce install weight for most users. This is a maintainer decision (it would be a breaking change for anyone not opting in) — flagging here for discussion, not implementing.

## Test plan

- [ ] CI passes on all matrix entries
- [ ] `nox -s build` produces a valid wheel and check-wheel-contents is satisfied
- [ ] Confirm prek-action runs correctly in the lint job