### PR TITLE
refactor(modeling): attrs modernization and dead-code removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+* Modeling subsystem (`modeling/`):
+  - Migrated `ModelDecay` and `AmplitudeChain` from old-style `@attr.s`/`attr.ib` to modern `@attrs.define`/`attrs.field`.
+  - Removed dead `graphviz` import guard in `decay.py` (graphviz is a hard dependency).
+  - Removed unused local variables `a`, `b` in `make_lineshape` methods of `GooFitChain` and `GooFitPyChain`.
+  - Removed unreachable `if not spin_factors:` branches in `make_spinfactor` (`spinfactors` raises `LineFailure` rather than returning empty).
+  - Fixed sequential `if` checks in `__main__.py` `main` to use `elif`.
+
 * CI and tests:
   - Several improvements, enhancements and clean_ups.
   - Removed dead `filterwarnings` ignore for PyArrow/pandas deprecation (pandas >=2.2.2 no longer emits it).

--- a/src/decaylanguage/__main__.py
+++ b/src/decaylanguage/__main__.py
@@ -21,7 +21,7 @@ class DecayLanguageDecay(cli.Application):
     def main(self, filename):
         if self.generator == "goofit":
             ampgen2goofit(filename)
-        if self.generator == "goofitpy":
+        elif self.generator == "goofitpy":
             ampgen2goofitpy(filename)
 
 

--- a/src/decaylanguage/modeling/amplitudechain.py
+++ b/src/decaylanguage/modeling/amplitudechain.py
@@ -17,7 +17,7 @@ from enum import Enum
 from itertools import product
 from typing import ClassVar
 
-import attr
+import attrs
 import numpy as np
 import pandas as pd
 from lark import Lark
@@ -38,22 +38,31 @@ class LS(Enum):
     FOCUS = 3
 
 
-@attr.s(slots=True)
+@attrs.define(order=True)
 class AmplitudeChain(ModelDecay):
     'This is a chain of decays (a "line")'
 
-    lineshape = attr.ib(None)
-    spinfactor = attr.ib(None)
-    amp = attr.ib(
-        1 + 0j, eq=False, order=False, validator=attr.validators.instance_of(complex)
+    lineshape = attrs.field(default=None)
+    spinfactor = attrs.field(default=None)
+    amp = attrs.field(
+        default=1 + 0j,
+        eq=False,
+        order=False,
+        validator=attrs.validators.instance_of(complex),
     )
-    err = attr.ib(
-        0 + 0j, eq=False, order=False, validator=attr.validators.instance_of(complex)
+    err = attrs.field(
+        default=0 + 0j,
+        eq=False,
+        order=False,
+        validator=attrs.validators.instance_of(complex),
     )
-    fix = attr.ib(
-        True, eq=False, order=False, validator=attr.validators.instance_of(bool)
+    fix = attrs.field(
+        default=True,
+        eq=False,
+        order=False,
+        validator=attrs.validators.instance_of(bool),
     )
-    name = attr.ib(None)
+    name = attrs.field(default=None)
 
     # Class members keep track of additions
     all_particles: ClassVar[Particle] = set()

--- a/src/decaylanguage/modeling/decay.py
+++ b/src/decaylanguage/modeling/decay.py
@@ -9,32 +9,24 @@ A general base class representing decays.
 
 from __future__ import annotations
 
-import warnings
 from itertools import product
 
-import attr
+import attrs
+import graphviz
 
 from ..utils import iter_flatten
 
-try:
-    import graphviz
-except ImportError:
-    graphviz = None
-    warnings.warn(
-        "Graphviz is not installed. Line display not available.", stacklevel=1
-    )
 
-
-@attr.s(slots=True)
+@attrs.define(order=True)
 class ModelDecay:
     """
     This describes a decay very generally, with search and print features.
     Subclassed for further usage.
     """
 
-    particle = attr.ib()
-    daughters = attr.ib([], converter=lambda x: x if x else [])
-    name = attr.ib(None)
+    particle = attrs.field()
+    daughters = attrs.field(factory=list)
+    name = attrs.field(default=None)
 
     def __attrs_post_init__(self):
         if self.name is None:
@@ -114,20 +106,18 @@ class ModelDecay:
             name += "{" + ",".join(map(str, self.daughters)) + "}"
         return name
 
-    if graphviz:
+    def _make_graphviz(self):
+        d = graphviz.Digraph()
+        d.attr(labelloc="t", label=str(self))
+        self._add_nodes(d)
+        return d
 
-        def _make_graphviz(self):
-            d = graphviz.Digraph()
-            d.attr(labelloc="t", label=str(self))
-            self._add_nodes(d)
-            return d
-
-        def _repr_mimebundle_(self, include=None, exclude=None, **kwargs):
-            try:
-                return self._make_graphviz()._repr_mimebundle_(
-                    include=include, exclude=exclude, **kwargs
-                )
-            except AttributeError:
-                return {
-                    "image/svg+xml": self._make_graphviz()._repr_svg_()
-                }  # for graphviz < 0.19
+    def _repr_mimebundle_(self, include=None, exclude=None, **kwargs):
+        try:
+            return self._make_graphviz()._repr_mimebundle_(
+                include=include, exclude=exclude, **kwargs
+            )
+        except AttributeError:
+            return {
+                "image/svg+xml": self._make_graphviz()._repr_svg_()
+            }  # for graphviz < 0.19

--- a/src/decaylanguage/modeling/goofit.py
+++ b/src/decaylanguage/modeling/goofit.py
@@ -273,11 +273,6 @@ class GooFitChain(AmplitudeChain):
         """
         name = self.name
         par = self.particle.programmatic_name
-        a = structure[0] + 1
-        b = structure[1] + 1
-        # order assignment
-        if a > b:
-            a, b = b, a
         L = self.L
         radius = 5.0 if "c" in self.particle.quarks.lower() else 1.5
 
@@ -319,16 +314,11 @@ class GooFitChain(AmplitudeChain):
         intro = "    spin_factor_list.push_back(std::vector<SpinFactor*>({\n"
         factor = []
         for structure in self.list_structure(final_states):
-            if not spin_factors:
+            for spin_factor in spin_factors:
+                structure_list = ", ".join(map(str, structure))
                 factor.append(
-                    f"        // TODO: Spin factor not implemented yet for {self.spindetails()}"
+                    f'        new SpinFactor("SF", SF_4Body::{spin_factor.name:37}, {structure_list})'
                 )
-            else:
-                for spin_factor in spin_factors:
-                    structure_list = ", ".join(map(str, structure))
-                    factor.append(
-                        f'        new SpinFactor("SF", SF_4Body::{spin_factor.name:37}, {structure_list})'
-                    )
         exit_ = "\n    }));\n"
         return intro + ",\n".join(factor) + exit_
 
@@ -620,11 +610,6 @@ class GooFitPyChain(AmplitudeChain):
         """
         name = self.name
         par = self.particle.programmatic_name
-        a = structure[0] + 1
-        b = structure[1] + 1
-        # order assignment
-        if a > b:
-            a, b = b, a
         L = int(self.L)
         radius = 5.0 if "c" in self.particle.quarks.lower() else 1.5
 
@@ -666,16 +651,11 @@ class GooFitPyChain(AmplitudeChain):
         intro = "spin_factor_list.append((\n"
         factor = []
         for structure in self.list_structure(final_states):
-            if not spin_factors:
+            for spin_factor in spin_factors:
+                structure_list = ", ".join(map(str, structure))
                 factor.append(
-                    f"        // TODO: Spin factor not implemented yet for {self.spindetails()}"
+                    f'        SpinFactor("SF", SF_4Body.{spin_factor.name:37}, {structure_list})'
                 )
-            else:
-                for spin_factor in spin_factors:
-                    structure_list = ", ".join(map(str, structure))
-                    factor.append(
-                        f'        SpinFactor("SF", SF_4Body.{spin_factor.name:37}, {structure_list})'
-                    )
         exit_ = "))\n"
         return intro + ",\n".join(factor) + exit_
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Scoped modernization and dead-code removal in the `modeling/` subsystem. Part of #581.

**Note:** A parallel modeling correctness-fix PR exists. Merge that one first; this PR rebases easily since it only touches style/structure, not logic.

- **attrs modernization**: `ModelDecay` (`decay.py`) and `AmplitudeChain` (`amplitudechain.py`) migrated from deprecated `@attr.s`/`attr.ib` to `@attrs.define`/`attrs.field`. `order=True` is passed explicitly to `attrs.define` to preserve the comparison/ordering semantics of the old `@attr.s` default (which defaulted to `order=True`; `attrs.define` defaults to `order=False`). All validators and `eq=False`/`order=False` per-field flags are preserved.
- **Dead graphviz guard removed**: `decay.py` had a `try/except ImportError` around `import graphviz` that emitted a `warnings.warn` (which would be an error under the test config anyway) and conditionally defined `_make_graphviz` and `_repr_mimebundle_` methods. Since `graphviz>=0.12.0` is a hard dependency in `pyproject.toml`, the guard is dead; both methods are now defined unconditionally.
- **Unused locals dropped**: `make_lineshape` in both `GooFitChain` and `GooFitPyChain` computed `a` and `b` from `structure[0]+1` / `structure[1]+1`, swapped them if out of order, then never used them. Removed.
- **Unreachable branches removed**: `make_spinfactor` in both classes had an `if not spin_factors: …` guard, but `self.spinfactors` raises `LineFailure` rather than returning an empty list when the spin factor is unknown — so the guard can never be reached. Removed, leaving the `for spin_factor in spin_factors` loop unconditional.
- **`elif` in `__main__.py`**: The two sequential `if` checks on `self.generator` are mutually exclusive (it's a `cli.Set("goofit", "goofitpy")`) — changed second `if` to `elif`.

## Test plan

- [x] `uv run pytest` — 299 passed, 1 skipped (no changes to generated output in `tests/output/`)
- [x] `prek -a --quiet` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)