### PR TITLE
refactor(decay): modernize decay/ and utils/ subsystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Universal representation of decay chains:
+  - Mechanical modernizations in `decay/` and `utils/`: removed obsolete `CounterStr` TYPE_CHECKING workaround (subclass `Counter[str]` directly), fixed `tuple[str]`/`tuple[int]` → `tuple[str, ...]`/`tuple[int, ...]` annotations, widened `DecayMode.metadata` type to `dict[str, Any]`, corrected constructor docstrings, converted `str.format` to f-strings, removed stray `from None` outside except, dropped unused `__slots__` entry, promoted local `DecayChain` import to module level, reused `_has_no_subdecay` in viewer, collapsed repetitive `graph_attr`/`node_attr`/`edge_attr` update loop, fixed `_repr_mimebundle_` include/exclude type annotations, and fixed `DescriptorFormat.__exit__` `*args` annotation.
+
 * CI and tests:
   - Several improvements, enhancements and clean_ups.
   - Removed dead `filterwarnings` ignore for PyArrow/pandas deprecation (pandas >=2.2.2 no longer emits it).

--- a/src/decaylanguage/decay/decay.py
+++ b/src/decaylanguage/decay/decay.py
@@ -11,7 +11,7 @@ from collections import Counter
 from collections.abc import Collection, Iterable, Iterator, Sequence
 from copy import deepcopy
 from itertools import product
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import Any, TypedDict
 
 from particle import PDGID, ParticleNotFound
 from particle.converters import EvtGenName2PDGIDBiMap
@@ -19,11 +19,6 @@ from particle.exceptions import MatchingIDNotFound
 
 from .._compat.typing import Self
 from ..utils import DescriptorFormat, charge_conjugate_name
-
-if TYPE_CHECKING:
-    CounterStr = Counter[str]  # pragma: no cover
-else:
-    CounterStr = Counter
 
 
 class DecayModeDict(TypedDict):
@@ -36,7 +31,7 @@ class DecayModeDict(TypedDict):
 DecayChainDict = dict[str, list[DecayModeDict]]
 
 
-class DaughtersDict(CounterStr):
+class DaughtersDict(Counter[str]):
     """
     Class holding a decay final state as a dictionary.
     It is a building block for the digital representation of full decay chains.
@@ -200,7 +195,7 @@ class DecayMode:
         self,
         bf: float = 0,
         daughters: (
-            DaughtersDict | dict[str, int] | list[str] | tuple[str] | str | None
+            DaughtersDict | dict[str, int] | list[str] | tuple[str, ...] | str | None
         ) = None,
         **info: Any,
     ) -> None:
@@ -216,7 +211,7 @@ class DecayMode:
         info: keyword arguments, optional
             Decay mode model information and/or user metadata (aka extra info)
             By default the following elements are always created:
-            dict(model=None, model_params=None).
+            dict(model='', model_params='').
             The user can provide any metadata, see the examples below.
 
         Note
@@ -258,7 +253,7 @@ class DecayMode:
             daughters = info.pop("fs")
         self.daughters = DaughtersDict(daughters)
 
-        self.metadata: dict[str, str | None] = {"model": "", "model_params": ""}
+        self.metadata: dict[str, Any] = {"model": "", "model_params": ""}
         self.metadata.update(**info)
 
     @classmethod
@@ -309,7 +304,7 @@ class DecayMode:
     def from_pdgids(
         cls,
         bf: float = 0,
-        daughters: list[int] | tuple[int] | None = None,
+        daughters: list[int] | tuple[int, ...] | None = None,
         **info: Any,
     ) -> Self:
         """
@@ -324,7 +319,7 @@ class DecayMode:
         info: keyword arguments, optional
             Decay mode model information and/or user metadata (aka extra info)
             By default the following elements are always created:
-            dict(model=None, model_params=None).
+            dict(model='', model_params='').
             The user can provide any metadata, see the examples below.
 
         Note
@@ -363,16 +358,16 @@ class DecayMode:
         """
         Make a nice high-density string for all decay-mode properties and info.
         """
-        val = """Daughters: {daughters} , BF: {bf:<15.8g}
-    Decay model: {model} {model_params}""".format(
-            daughters=" ".join(self.daughters),
-            bf=self.bf,
-            model=self.metadata["model"],
-            model_params=(
-                self.metadata["model_params"]
-                if self.metadata["model_params"] is not None
-                else ""
-            ),
+        _daughters = " ".join(self.daughters)
+        _model = self.metadata["model"]
+        _model_params = (
+            self.metadata["model_params"]
+            if self.metadata["model_params"] is not None
+            else ""
+        )
+        val = (
+            f"Daughters: {_daughters} , BF: {self.bf:<15.8g}\n"
+            f"    Decay model: {_model} {_model_params}"
         )
 
         keys = [k for k in self.metadata if k not in ("model", "model_params")]
@@ -440,11 +435,8 @@ class DecayMode:
         return len(self.daughters)
 
     def __repr__(self) -> str:
-        return "<{self.__class__.__name__}: daughters={daughters}, BF={bf}>".format(
-            self=self,
-            daughters=self.daughters.to_string() if len(self.daughters) > 0 else "[]",
-            bf=self.bf,
-        )
+        daughters = self.daughters.to_string() if len(self.daughters) > 0 else "[]"
+        return f"<{self.__class__.__name__}: daughters={daughters}, BF={self.bf}>"
 
     def __str__(self) -> str:
         return repr(self)
@@ -770,9 +762,7 @@ class DecayChain:
         >>> dc = DecayChain('D0', {'D0':dm1, 'K_S0':dm2, 'pi0':dm3})
         """
         if mother not in decays:
-            raise RuntimeError(
-                "Input decay modes do not include the mother particle!"
-            ) from None
+            raise RuntimeError("Input decay modes do not include the mother particle!")
 
         self.mother = mother
         self.decays = decays

--- a/src/decaylanguage/decay/viewer.py
+++ b/src/decaylanguage/decay/viewer.py
@@ -12,15 +12,14 @@ see the ``DecFileParser`` class.
 from __future__ import annotations
 
 import itertools
-from typing import TYPE_CHECKING, Any
+from collections.abc import Iterable
+from typing import Any
 
 import graphviz
-
-if TYPE_CHECKING:
-    from decaylanguage.decay.decay import DecayChain
-
 from particle import latex_to_html_name
 from particle.converters.bimap import DirectionalMap, DirectionalMaps
+
+from decaylanguage.decay.decay import DecayChain, _has_no_subdecay
 
 counter = iter(itertools.count())
 
@@ -52,7 +51,7 @@ class DecayChainViewer:
     >>> dcv.graph.render(filename="test", format="pdf", view=True, cleanup=True)    # doctest: +SKIP
     """
 
-    __slots__ = ("_chain", "_graph", "_graph_attributes", "_show_effective_bf")
+    __slots__ = ("_chain", "_graph", "_show_effective_bf")
 
     def __init__(
         self,
@@ -81,12 +80,8 @@ class DecayChainViewer:
         decaylanguage.DecayChain: class for building a decay chain programmatically.
         """
         # Accept DecayChain objects directly, converting to dict internally
-        from decaylanguage.decay.decay import (  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
-            DecayChain as _DecayChain,
-        )
-
         chain: dict[str, list[Any]]
-        if isinstance(decaychain, _DecayChain):
+        if isinstance(decaychain, DecayChain):
             chain = decaychain.to_dict()
         else:
             chain = decaychain
@@ -182,7 +177,7 @@ class DecayChainViewer:
                 _list_parts = subchain[idm]["fs"]
                 _bf = subchain[idm]["bf"]
                 _effective_bf = effective_bf * float(_bf)  # type: ignore[arg-type]
-                if not has_subdecay(_list_parts):  # type: ignore[arg-type]
+                if _has_no_subdecay(_list_parts):  # type: ignore[arg-type]
                     _ref = new_node_no_subchain(_list_parts, _effective_bf)  # type: ignore[arg-type]
                     if link_pos is None:
                         self.graph.edge(top_node, _ref, label=str(_bf))
@@ -208,9 +203,6 @@ class DecayChainViewer:
                                 link_pos=i,
                                 effective_bf=_effective_bf,
                             )
-
-        def has_subdecay(ds: list[Any]) -> bool:
-            return not all(isinstance(p, str) for p in ds)
 
         k = next(iter(self._chain.keys()))
         label = html_table_label([k], add_tags=True, bgcolor="#568dba")
@@ -246,15 +238,13 @@ class DecayChainViewer:
         graph_attr = self._get_graph_defaults()
         node_attr = self._get_node_defaults()
         edge_attr = self._get_edge_defaults()
-        if "graph_attr" in attrs:
-            graph_attr.update(**attrs["graph_attr"])
-            attrs.pop("graph_attr")
-        if "node_attr" in attrs:
-            node_attr.update(**attrs["node_attr"])
-            attrs.pop("node_attr")
-        if "edge_attr" in attrs:
-            edge_attr.update(**attrs["edge_attr"])
-            attrs.pop("edge_attr")
+        for key, attr in (
+            ("graph_attr", graph_attr),
+            ("node_attr", node_attr),
+            ("edge_attr", edge_attr),
+        ):
+            if key in attrs:
+                attr.update(**attrs.pop(key))
 
         arguments = self._get_default_arguments()
         arguments.update(**attrs)  # type: ignore[call-overload]
@@ -287,8 +277,8 @@ class DecayChainViewer:
 
     def _repr_mimebundle_(
         self,
-        include: bool | None = None,
-        exclude: bool | None = None,
+        include: Iterable[str] | None = None,
+        exclude: Iterable[str] | None = None,
         **kwargs: Any,
     ) -> Any:  # pragma: no cover
         """

--- a/src/decaylanguage/utils/utilities.py
+++ b/src/decaylanguage/utils/utilities.py
@@ -101,7 +101,7 @@ class DescriptorFormat:
     def __enter__(self) -> None:
         self.set_config(**self.new_config)
 
-    def __exit__(self, *args: list[Any]) -> None:
+    def __exit__(self, *args: object) -> None:
         self.set_config(**self.old_config)
 
     @staticmethod


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Mechanical simplifications and modernizations in the `decay/` subsystem. Part of #581.

- **`CounterStr` removal**: The `TYPE_CHECKING` workaround (`CounterStr = Counter[str]` / `Counter`) is obsolete since Python 3.9; `DaughtersDict` now subclasses `Counter[str]` directly.
- **Annotation fixes**: `tuple[str]`/`tuple[int]` → `tuple[str, ...]`/`tuple[int, ...]`; `DecayMode.metadata` widened from `dict[str, str | None]` to `dict[str, Any]` (arbitrary values like `year=2019` and nested dicts are stored); `_repr_mimebundle_` `include`/`exclude` `bool | None` → `Iterable[str] | None` to match graphviz/IPython contract; `DescriptorFormat.__exit__` `*args: list[Any]` → `*args: object`.
- **Docstring fix**: constructor docstrings incorrectly claimed `model=None, model_params=None` defaults; corrected to `model='', model_params=''`.
- **f-strings**: `str.format` blocks in `DecayMode.describe()` and `DecayMode.__repr__` converted to f-strings.
- **Stray `from None`**: `raise RuntimeError(...) from None` outside any `except` block in `DecayChain.__init__` — dropped the `from None`.
- **`__slots__` cleanup**: Removed `_graph_attributes` from `DecayChainViewer.__slots__` (never assigned).
- **`DecayChain` import in viewer.py**: Promoted from a runtime-local import (with `noqa`/`pylint` suppressions) to a normal module-level import. Confirmed no circular import: `decay.py` does not import `viewer.py`.
- **`_has_no_subdecay` reuse**: viewer.py had a local `has_subdecay` function that negated `_has_no_subdecay` from `decay.py:453`; removed the duplicate and imported the canonical function.
- **`_instantiate_graph` loop**: Collapsed three near-identical `if key in attrs: attr.update(**attrs.pop(key))` blocks into a single loop over `(graph_attr, node_attr, edge_attr)`.

## Test plan

- [x] `uv run pytest` — 299 passed, 1 skipped (expected)
- [x] `prek -a --quiet` — all hooks pass (ruff, mypy strict, etc.)