### PR TITLE
perf(dec): speed up build_decay_chains and DecFileParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+* Parsing of decay files (aka .dec files):
+  - Performance improvements in `DecFileParser`: `build_decay_chains` now caches
+    sub-chains by particle name when no `minimum_effective_bf` cut is requested
+    (~9x faster on `DECAY_BELLE2.DEC`), `_find_decay_modes` uses a lazily-built
+    name→tree index instead of a linear scan, `_check_parsed_decays` uses
+    `collections.Counter` instead of repeated `list.count`/`list.remove`, the
+    decay-model regex is built once per grammar, and Lark parsers are cached and
+    reused across parser instances.
+
 * CI and tests:
   - Several improvements, enhancements and clean_ups.
   - Removed dead `filterwarnings` ignore for PyArrow/pandas deprecation (pandas >=2.2.2 no longer emits it).

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -42,6 +42,7 @@ import copy
 import os
 import re
 import warnings
+from collections import Counter
 from collections.abc import Callable, Iterable
 from functools import cache
 from io import StringIO
@@ -70,6 +71,40 @@ class DecayNotFound(RuntimeError):
     pass
 
 
+@cache
+def _build_lark_parser(
+    grammar: str,
+    parser: str,
+    lexer: str,
+    decay_models: tuple[str, ...],
+) -> Lark:
+    """
+    Build (and cache) a Lark parser for the given grammar and EvtGen decay
+    models. Constructing a Lark parser is comparatively expensive, and it only
+    depends on the grammar text, the parser/lexer choice and the set of decay
+    model names injected into the ``MODEL_NAME`` terminal. Caching on those
+    inputs lets repeated ``DecFileParser`` instances reuse a single parser.
+
+    A cached Lark parser is safe to reuse across ``.parse()`` calls: parsing
+    produces a fresh tree each time and does not mutate the parser.
+    """
+    # Build the model regex alternation once.
+    modelstr = rf"(?:{'|'.join(re.escape(dm) for dm in sorted(decay_models, key=len, reverse=True))})"
+
+    def edit_model_name_terminals(t: TerminalDef) -> None:
+        if t.name == "MODEL_NAME":
+            t.pattern.value = t.pattern.value.replace(
+                "MODEL_NAME_PLACEHOLDER", modelstr
+            )
+
+    return Lark(
+        grammar,
+        parser=parser,
+        lexer=lexer,
+        edit_terminals=edit_model_name_terminals,
+    )
+
+
 class DecFileParser:
     """
     The class to parse a .dec decay file.
@@ -84,6 +119,7 @@ class DecFileParser:
         "_additional_decay_models",
         "_dec_file",
         "_dec_file_names",
+        "_decay_modes_index",
         "_grammar",
         "_grammar_info",
         "_include_ccdecays",
@@ -138,6 +174,10 @@ class DecFileParser:
         self._parsed_decays: None | (
             Any
         ) = None  # Particle decays found in the decay file
+        # Lazily-built index mapping a mother particle name to the tuple of its
+        # decay-mode Trees, avoiding repeated linear scans of self._parsed_decays.
+        # Invalidated (set to None) whenever self._parsed_decays is modified.
+        self._decay_modes_index: dict[str, tuple[Any, ...]] | None = None
 
         self._additional_decay_models: None | Iterable[str] = (
             None  # Additional decay models not (yet) known to DecayLanguage
@@ -197,14 +237,25 @@ class DecFileParser:
             if k not in ("lark_file", "parser", "lexer", "edit_terminals")
         }
 
-        # Instantiate the Lark parser according to chosen settings
-        parser = Lark(
-            self.grammar(),
-            parser=opts["parser"],
-            lexer=opts["lexer"],
-            edit_terminals=opts["edit_terminals"],
-            **extraopts,
-        )
+        # Instantiate the Lark parser according to chosen settings.
+        # In the common case (no extra grammar options), reuse a cached parser
+        # keyed on the grammar text, parser/lexer choice and decay-model names,
+        # since building a Lark parser is comparatively expensive.
+        if extraopts:
+            parser = Lark(
+                self.grammar(),
+                parser=opts["parser"],
+                lexer=opts["lexer"],
+                edit_terminals=opts["edit_terminals"],
+                **extraopts,
+            )
+        else:
+            parser = _build_lark_parser(
+                self.grammar(),
+                opts["parser"],
+                opts["lexer"],
+                self._decay_models_tuple(),
+            )
         self._parsed_dec_file = parser.parse(self._dec_file)
 
         # At last, find all particle decays defined in the .dec decay file ...
@@ -218,6 +269,7 @@ class DecFileParser:
             )
             for tree in self._parsed_decays  # type: ignore[union-attr]
         ]
+        self._decay_modes_index = None
 
         # Check whether certain decay model parameters are defined via
         # variable names with actual values provided via 'Define' statements,
@@ -321,18 +373,28 @@ class DecFileParser:
             **options,
         }
 
+    def _decay_models_tuple(self) -> tuple[str, ...]:
+        """
+        Return the tuple of EvtGen decay model names to inject into the grammar,
+        i.e. the known models plus any added via ``load_additional_decay_models``.
+        """
+        if self._additional_decay_models is None:
+            return known_decay_models
+        return tuple(
+            chain.from_iterable([known_decay_models, self._additional_decay_models])
+        )
+
     def _generate_edit_terminals_callback(self) -> Callable[[TerminalDef], None]:
         """
         This closure creates the callback used by Lark to modify the grammar terminals
         and inject the names of the EvtGen models.
         """
 
-        if self._additional_decay_models is None:
-            decay_models = known_decay_models  # type: tuple[str, ...]
-        else:
-            decay_models = tuple(
-                chain.from_iterable([known_decay_models, self._additional_decay_models])
-            )
+        decay_models = self._decay_models_tuple()
+
+        # Build the model regex alternation once, rather than rebuilding it for
+        # every terminal passed to the callback below.
+        modelstr = rf"(?:{'|'.join(re.escape(dm) for dm in sorted(decay_models, key=len, reverse=True))})"
 
         def edit_model_name_terminals(t: TerminalDef) -> None:
             """
@@ -341,7 +403,6 @@ class DecFileParser:
             The decay models are sorted by length and escaped to match the default Lark behavior.
             """
 
-            modelstr = rf"(?:{'|'.join(re.escape(dm) for dm in sorted(decay_models, key=len, reverse=True))})"
             if t.name == "MODEL_NAME":
                 t.pattern.value = t.pattern.value.replace(
                     "MODEL_NAME_PLACEHOLDER", modelstr
@@ -561,6 +622,7 @@ class DecFileParser:
         see 'self._add_charge_conjugate_decays()'.
         """
         self._parsed_decays = get_decays(self._parsed_dec_file)
+        self._decay_modes_index = None
 
         # Check for duplicates - should be considered a bug in the .dec file!
         self._check_parsed_decays()
@@ -607,6 +669,7 @@ Skipping creation of these copied decay trees.""".format("\n".join(misses))
 
         # Actually add all these copied decays to the list of decays!
         self._parsed_decays.extend(copied_decays)  # type: ignore[union-attr]
+        self._decay_modes_index = None
 
     def _add_charge_conjugate_decays(self) -> None:
         """
@@ -711,6 +774,7 @@ Skipping creation of charge-conjugate decay Tree."""
 
         # ... and add all these charge-conjugate decays to the list of decays!
         self._parsed_decays.extend(cdecays)  # type: ignore[union-attr]
+        self._decay_modes_index = None
 
     def _check_parsing(self) -> None:
         """Has the .parse() method been called already?"""
@@ -724,11 +788,13 @@ Skipping creation of charge-conjugate decay Tree."""
 
         Duplicates are removed, starting from the second occurrence.
         """
-        # Issue a helpful warning if duplicates are found
+        # Count occurrences of each decay mother name in a single pass
         lmn = self.list_decay_mother_names()
-        duplicates = set()
-        if self.number_of_decays != len(set(lmn)):
-            duplicates = {n for n in lmn if lmn.count(n) > 1}
+        counts = Counter(lmn)
+        duplicates = {n for n, c in counts.items() if c > 1}
+
+        # Issue a helpful warning if duplicates are found
+        if duplicates:
             msg = """The following particle(s) is(are) redefined in the input .dec file with 'Decay': {}!
 All but the first occurrence will be discarded/removed ...""".format(
                 ", ".join(duplicates)
@@ -736,20 +802,17 @@ All but the first occurrence will be discarded/removed ...""".format(
 
             warnings.warn(msg, stacklevel=2)
 
-        # Create a list with all occurrences to remove
-        # (duplications means multiple instances to remove)
-        duplicates_to_remove = []
-        for item in duplicates:
-            c = lmn.count(item)
-            if c > 1:
-                duplicates_to_remove.extend([item] * (c - 1))
-
-        # Actually remove all but the first occurrence of duplicate decays
-        for tree in reversed(self._parsed_decays):  # type: ignore[arg-type]
-            val = tree.children[0].children[0].value
-            if val in duplicates_to_remove:
-                duplicates_to_remove.remove(val)
-                self._parsed_decays.remove(tree)  # type: ignore[union-attr]
+            # Rebuild the list keeping only the first occurrence of each name
+            seen: set[str] = set()
+            kept = []
+            for tree in self._parsed_decays:  # type: ignore[union-attr]
+                val = tree.children[0].children[0].value
+                if val in seen:
+                    continue
+                seen.add(val)
+                kept.append(tree)
+            self._parsed_decays = kept
+            self._decay_modes_index = None
 
     @property
     def number_of_decays(self) -> int:
@@ -778,11 +841,24 @@ All but the first occurrence will be discarded/removed ...""".format(
         """
         self._check_parsing()
 
-        for decay_Tree in self._parsed_decays:  # type: ignore[union-attr]
-            if get_decay_mother_name(decay_Tree) == mother:
-                return tuple(decay_Tree.find_data("decayline"))
+        if self._decay_modes_index is None:
+            # Build the index once; later lookups are O(1). The index is
+            # invalidated (reset to None) whenever self._parsed_decays changes.
+            index: dict[str, tuple[Any, ...]] = {}
+            for decay_Tree in self._parsed_decays:  # type: ignore[union-attr]
+                name = get_decay_mother_name(decay_Tree)
+                # Keep the first occurrence, mirroring the old behavior of
+                # returning the first matching decay Tree.
+                if name not in index:
+                    index[name] = tuple(decay_Tree.find_data("decayline"))
+            self._decay_modes_index = index
 
-        raise DecayNotFound(f"Decays of particle '{mother}' not found in .dec file!")
+        try:
+            return self._decay_modes_index[mother]
+        except KeyError:
+            raise DecayNotFound(
+                f"Decays of particle '{mother}' not found in .dec file!"
+            ) from None
 
     def list_decay_modes(self, mother: str, pdg_name: bool = False) -> list[list[str]]:
         """
@@ -1074,8 +1150,16 @@ All but the first occurrence will be discarded/removed ...""".format(
         # Standardize inputs for hashing
         stable_set = frozenset(stable_particles)
 
-        # Define the actual computation logic within a helper function
-        # This function will return the raw, mutable result, which will be cached.
+        # When no branching-fraction cut is requested, the decay subtree of a
+        # given particle is independent of the path taken to reach it, so we can
+        # key the cache on the particle name alone. This makes a particle that
+        # appears under several parents recurse (and deepcopy) only once.
+        # With a BF cut active, the result genuinely depends on the effective BF
+        # accumulated along the path, so that value must remain part of the key.
+        cache_on_name_only = minimum_effective_bf is None
+
+        # Define the actual computation logic within a helper function.
+        # This function returns the raw, mutable result, which is cached.
         @cache
         def _cached_recurse_raw(
             p_name: str,
@@ -1116,16 +1200,16 @@ All but the first occurrence will be discarded/removed ...""".format(
             return {p_name: info}
 
         # This is the wrapper function that external callers (and recursive calls) will use.
-        # It always returns a deepcopy of the (potentially cached) raw result.
+        # It always returns a deepcopy of the (potentially cached) raw result,
+        # since callers mutate the returned dict in place.
         def _recurse(
             p_name: str,
             current_effective_bf: float = 1.0,
         ) -> dict[str, list[DecayModeDict]]:
-            raw_result = _cached_recurse_raw(p_name, current_effective_bf)
+            # Collapse the cache key to the particle name when no BF cut applies.
+            key_bf = 1.0 if cache_on_name_only else current_effective_bf
+            raw_result = _cached_recurse_raw(p_name, key_bf)
             return copy.deepcopy(raw_result)
-
-        # Clear the cache to not cause problem in the case the DecFileParser object (self) is modified
-        _cached_recurse_raw.cache_clear()
 
         return _recurse(mother)
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #581

Performance improvements to the `dec/` subsystem (`src/decaylanguage/dec/dec.py`). All changes are behavior-preserving; `build_decay_chains` output was verified byte-for-byte identical (via pickle comparison) against `main` for several `stable_particles` and `minimum_effective_bf` variants.

## Changes

1. **`build_decay_chains` cache** — the inner `@cache`d recursion keyed on `(p_name, current_effective_bf)`. With the default `minimum_effective_bf=None`, the effective BF varies along every path, so a particle reachable under multiple parents was fully re-recursed and re-deepcopied each time, making the cache nearly useless. When no BF cut is requested, the cache key is now collapsed to `p_name` alone. The per-call `cache_clear()` (dead code on a freshly-created closure) was removed. The deepcopy-before-mutation contract is preserved, so shared cached subtrees stay safe.
2. **`_find_decay_modes` index** — replaced the per-lookup linear scan of `_parsed_decays` with a lazily-built `name -> tuple(decayline Trees)` index. The index is invalidated (reset to `None`) wherever `_parsed_decays` is reassigned/extended (`parse`, `_find_parsed_decays`, `_check_parsed_decays`, `_add_decays_to_be_copied`, `_add_charge_conjugate_decays`).
3. **`_check_parsed_decays`** — replaced `lmn.count(...)` comprehensions plus repeated `.count`/`.remove` (and removal from the list while iterating `reversed(...)`) with a single `collections.Counter` pass and a list rebuild keeping first occurrences. Warning behavior is unchanged.
4. **`modelstr` built once** — the decay-model regex alternation was rebuilt for every terminal in the `edit_terminals` callback; it is now computed once.
5. **Lark parser cache** (optional) — a module-level `@cache`d `_build_lark_parser` keyed on `(grammar, parser, lexer, decay_models_tuple)`. Most `.parse()` calls construct a fresh parser; reusing one avoids the ~10 ms Lark construction cost. Note this is a modest win — `parser.parse()` itself (~190 ms on `DECAY_BELLE2.DEC`) dominates `parse()`, so end-to-end `parse()` timing is dominated by noise. The cache only kicks in when no extra grammar options are passed (the common path); the `load_additional_decay_models` case is handled by keying on the decay-model tuple.

## Before / after

Timed on the shipped `DECAY_BELLE2.DEC` (median of 5 runs), comparing this branch against `main`:

| Operation | main | this branch | speedup |
|---|---|---|---|
| `build_decay_chains("D_s*+", stable_particles=[])` | 2.96 s | 0.35 s | ~8.5x |
| `build_decay_chains("D_s*+", minimum_effective_bf=0.1)` | 0.74 ms | 0.59 ms | ~unchanged (expected — BF cut still keys on bf) |
| `parse()` | ~0.5 s | ~0.5 s | parser-construction (~10 ms) saved; dominated by `parser.parse()` |

`pytest-benchmark` (`-m benchmark`, `DECAY_BELLE2.DEC`) on this branch: `test_build_decay_chains_benchmark` median ~0.38 s, `test_build_decay_chains_min_bf_benchmark` median ~0.53 ms.

## Validation

- `uv run pytest`: 299 passed, 1 skipped.
- `prek -a --quiet`: clean (ruff, ruff-format, mypy strict).
- `build_decay_chains` output verified identical to `main`.

## Scope notes

Deliberately did not touch the `DecayModelAliasReplacement._replacement` / `dict_model_aliases` deepcopy logic, nor `print_decay_modes`, `get_lineshape_settings`, `from_string`, `load_additional_decay_models` (owned by parallel PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
