### PR TITLE
feat: optional decaylanguage[modeling] extra for numpy/pandas/plumbum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Dependencies:
+  - Moved `numpy`, `pandas` and `plumbum` into an optional `decaylanguage[modeling]` extra; they are only needed by the `modeling` subpackage and the command-line interface. Core `.dec` parsing and decay-chain functionality no longer pull them in.
 * CI and tests:
   - Several improvements, enhancements and clean_ups.
   - Removed dead `filterwarnings` ignore for PyArrow/pandas deprecation (pandas >=2.2.2 no longer emits it).

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Just run the following:
 pip install decaylanguage
 ```
 
+The amplitude `modeling` subpackage and the command-line interface need a few
+extra dependencies (NumPy, pandas and plumbum). Install them with:
+
+```bash
+pip install "decaylanguage[modeling]"
+```
+
 You can use a virtual environment through pipenv or with `--user` if you know
 what those are. [Python
 3.10+](http://docs.python-guide.org/en/latest/starting/installation) supported
@@ -44,14 +51,17 @@ Required and compatibility dependencies will be automatically installed by pip.
 
 ### Required dependencies:
 
--   [NumPy](https://scipy.org/install.html): The numerical library for Python
--   [pandas](https://pandas.pydata.org/): Tabular data in Python
 -   [attrs](https://github.com/python-attrs/attrs): DataClasses for Python
 -   [graphviz](https://gitlab.com/graphviz/graphviz/): Render (DOT language) graph descriptions and visualizations of decay chains
 -   [lark](https://github.com/lark-parser/lark): A modern parsing library for Python
--   [plumbum](https://github.com/tomerfiliba/plumbum): Command line tools
 -   [hepunits](https://github.com/scikit-hep/hepunits): HEP units and constants
 -   [particle](https://github.com/scikit-hep/particle): PDG particle data and identification codes
+
+### Optional `modeling` dependencies:
+
+-   [NumPy](https://scipy.org/install.html): The numerical library for Python
+-   [pandas](https://pandas.pydata.org/): Tabular data in Python
+-   [plumbum](https://github.com/tomerfiliba/plumbum): Command line tools
 </p></details>
 
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Required and compatibility dependencies will be automatically installed by pip.
 -   [hepunits](https://github.com/scikit-hep/hepunits): HEP units and constants
 -   [particle](https://github.com/scikit-hep/particle): PDG particle data and identification codes
 
-### Optional `modeling` dependencies:
+### Optional `modeling` submodule dependencies:
 
 -   [NumPy](https://scipy.org/install.html): The numerical library for Python
 -   [pandas](https://pandas.pydata.org/): Tabular data in Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,19 +44,24 @@ dependencies = [
     "attrs>=19.2",
     "graphviz>=0.12.0",
     "lark>=1.0.0",
-    "numpy>=1.21.6",
-    "pandas>=1.4",
     "particle>=0.26.0",
     "hepunits>=2.4.0",
-    "plumbum>=1.7.0",
 ]
 dynamic = ["version"]
+
+[project.optional-dependencies]
+modeling = [
+    "numpy>=1.21.6",
+    "pandas>=1.4",
+    "plumbum>=1.7.0",
+]
 
 [dependency-groups]
 dev = [
     { include-group = "test" }
 ]
 docs = [
+    "decaylanguage[modeling]",
     "ipykernel",
     "jupyter-sphinx>=0.5",
     "myst-parser>=4",
@@ -67,6 +72,7 @@ docs = [
     "sphinx-copybutton>=0.5",
 ]
 test = [
+    "decaylanguage[modeling]",
     "pytest-benchmark>=5.2.0",
     "pytest-cov",
     "pytest>=6",

--- a/src/decaylanguage/__main__.py
+++ b/src/decaylanguage/__main__.py
@@ -7,9 +7,18 @@
 
 from __future__ import annotations
 
-from plumbum import cli
+try:
+    from plumbum import cli
 
-from decaylanguage.modeling.ampgen2goofit import ampgen2goofit, ampgen2goofitpy
+    from decaylanguage.modeling.ampgen2goofit import ampgen2goofit, ampgen2goofitpy
+except ModuleNotFoundError as err:
+    if err.name in {"numpy", "pandas", "plumbum"}:
+        msg = (
+            "The decaylanguage command-line interface requires extra dependencies; "
+            "install them with `pip install decaylanguage[modeling]`."
+        )
+        raise ModuleNotFoundError(msg) from err
+    raise
 
 
 class DecayLanguageDecay(cli.Application):

--- a/src/decaylanguage/modeling/__init__.py
+++ b/src/decaylanguage/modeling/__init__.py
@@ -5,7 +5,16 @@
 
 from __future__ import annotations
 
-from .amplitudechain import LS, AmplitudeChain
+try:
+    from .amplitudechain import LS, AmplitudeChain
+except ModuleNotFoundError as err:
+    if err.name in {"numpy", "pandas", "plumbum"}:
+        msg = (
+            "The decaylanguage modeling subpackage requires extra dependencies; "
+            "install them with `pip install decaylanguage[modeling]`."
+        )
+        raise ModuleNotFoundError(msg) from err
+    raise
 
 __all__ = ("LS", "AmplitudeChain")
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Follow-up to the open question in #585 (both maintainers agreed in the thread).

## Summary

`numpy`, `pandas` and `plumbum` were unconditional runtime dependencies, but only the `modeling` subpackage and the command-line interface use them. Users who only need `.dec` parsing or the universal decay-chain representation don't.

This moves them into an optional `decaylanguage[modeling]` extra.

- **`pyproject.toml`** — removed the three packages from core `dependencies`; added `[project.optional-dependencies] modeling`. The `test` and `docs` dependency groups self-reference `decaylanguage[modeling]`, so `uv run pytest`, `nox -s tests`, `nox -s pylint`, and `nox -s docs` are unchanged (doctest-modules and autodoc both import the `modeling` subpackage).
- **`src/decaylanguage/modeling/__init__.py`** / **`__main__.py`** — a missing `numpy`/`pandas`/`plumbum` now raises a clear `ModuleNotFoundError` pointing at `pip install decaylanguage[modeling]`. Genuine internal import errors still propagate unchanged.
- **`README.md`** — documents the extra; splits the dependency list into required vs. optional `modeling`.
- **`CHANGELOG.md`** — added a Dependencies note.

## Breaking change

Code that imports `decaylanguage.modeling` (e.g. `AmplitudeChain`, `GooFitChain`) or uses `python -m decaylanguage` must now install `decaylanguage[modeling]`.

## Validation

- `uv run pytest`: 299 passed, 1 skipped
- Clean **core-only** install: `import decaylanguage` works with no numpy/pandas/plumbum present; `import decaylanguage.modeling` and `python -m decaylanguage` emit the friendly install hint
- `prek -a --quiet`: clean
- Built wheel metadata: lean core `Requires-Dist` + `Provides-Extra: modeling` gating the three deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)