### PR TITLE
refactor(typing): reduce type: ignore comments (#435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Typing:
+  - Reviewed and reduced `# type: ignore` comments across `dec/`, `decay/`, and
+    `utils/` (#435). Several were replaced by proper annotations or `assert`
+    invariants (e.g. on `DecFileParser._parsed_decays`), turning silently
+    ignored errors into real runtime guards.
 * Parsing of decay files (aka .dec files):
   - Various improvements to the code, for more robustness.
   - Performance improvements in `DecFileParser`, with caching and lazily-built indexing where possible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## Unreleased
 
-* Typing:
-  - Reviewed and reduced `# type: ignore` comments across `dec/`, `decay/`, and
-    `utils/` (#435). Several were replaced by proper annotations or `assert`
-    invariants (e.g. on `DecFileParser._parsed_decays`), turning silently
-    ignored errors into real runtime guards.
 * Parsing of decay files (aka .dec files):
   - Various improvements to the code, for more robustness.
   - Performance improvements in `DecFileParser`, with caching and lazily-built indexing where possible.
@@ -50,6 +45,8 @@
   - Fixed `filter_lines()` to collect matched lines and residuals in a single pass instead of running the regex twice per line.
 * Dependencies:
   - Moved `numpy`, `pandas` and `plumbum` into an optional `decaylanguage[modeling]` extra; they are only needed by the `modeling` subpackage and the command-line interface. Core `.dec` parsing and decay-chain functionality no longer pull them in.
+* Miscellaneous -typing:
+  - Reviewed and reduced `# type: ignore` comments across submodules.
 * CI and tests:
   - Several improvements, enhancements and clean_ups.
   - Removed dead `filterwarnings` ignore for PyArrow/pandas deprecation (pandas >=2.2.2 no longer emits it).

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -142,6 +142,7 @@ class DecFileParser:
         )
 
         # Name(s) of the input decay file(s)
+        self._dec_file: str | None = None  # Content of input file(s)
         if filenames:
             self._dec_file_names = list(filenames)
 
@@ -156,16 +157,13 @@ class DecFileParser:
                     stream.write("\n")
 
             stream.seek(0)
-            # Content of input file(s)
             self._dec_file = stream.read()
         else:
             self._dec_file_names = []
-            self._dec_file = None  # type: ignore[assignment]
 
         self._parsed_dec_file: Tree | None = None  # Parsed decay file
-        self._parsed_decays: None | (
-            Any
-        ) = None  # Particle decays found in the decay file
+        # Particle decays found in the decay file
+        self._parsed_decays: list[Tree] | None = None
         # Lazily-built index mapping a mother particle name to the tuple of its
         # decay-mode Trees, avoiding repeated linear scans of self._parsed_decays.
         # Invalidated (set to None) whenever self._parsed_decays is modified.
@@ -266,6 +264,7 @@ class DecFileParser:
 
         # At last, find all particle decays defined in the .dec decay file ...
         self._find_parsed_decays()
+        assert self._parsed_decays is not None
         # Replace model aliases with the actual models and model parameters.
         # DecayModelAliasReplacement deep-copies each subtree at replacement
         # time, so the in-place mutations later done by
@@ -275,7 +274,7 @@ class DecFileParser:
             DecayModelAliasReplacement(model_alias_defs=dict_model_aliases).transform(
                 tree
             )
-            for tree in self._parsed_decays  # type: ignore[union-attr]
+            for tree in self._parsed_decays
         ]
         self._decay_modes_index = None
 
@@ -307,8 +306,9 @@ class DecFileParser:
         """
         if not self.grammar_loaded:
             self._load_grammar()
+        assert self._grammar is not None
 
-        return self._grammar  # type: ignore[return-value]
+        return self._grammar
 
     def grammar_info(self) -> dict[str, Any]:
         """
@@ -665,11 +665,12 @@ class DecFileParser:
         2) Method not meant to be used directly!
         """
         decays2copy = self.dict_decays2copy()
+        assert self._parsed_decays is not None
 
         # match name -> position in list self._parsed_decays
         name2treepos = {
             t.children[0].children[0].value: i
-            for i, t in enumerate(self._parsed_decays)  # type: ignore[arg-type]
+            for i, t in enumerate(self._parsed_decays)
         }
 
         # Make the copies taking care to change the name of the mother particle
@@ -677,7 +678,7 @@ class DecFileParser:
         misses = []
         for decay2copy, decay2becopied in decays2copy.items():
             try:
-                match = self._parsed_decays[name2treepos[decay2becopied]]  # type: ignore[index]
+                match = self._parsed_decays[name2treepos[decay2becopied]]
                 copied_decay = copy.deepcopy(match)
                 copied_decay.children[0].children[0].value = decay2copy
                 copied_decays.append(copied_decay)
@@ -690,7 +691,7 @@ Skipping creation of these copied decay trees.""".format("\n".join(misses))
             warnings.warn(msg, stacklevel=2)
 
         # Actually add all these copied decays to the list of decays!
-        self._parsed_decays.extend(copied_decays)  # type: ignore[union-attr]
+        self._parsed_decays.extend(copied_decays)
         self._decay_modes_index = None
 
     def _add_charge_conjugate_decays(self) -> None:
@@ -720,11 +721,12 @@ Skipping creation of these copied decay trees.""".format("\n".join(misses))
         if len(mother_names_ccdecays) == 0:
             return
 
+        assert self._parsed_decays is not None
+
         # Cross-check - make sure charge conjugate decays are not defined
         # with both 'Decay' and 'CDecay' statements!
         mother_names_decays = [
-            get_decay_mother_name(tree)
-            for tree in self._parsed_decays  # type: ignore[union-attr]
+            get_decay_mother_name(tree) for tree in self._parsed_decays
         ]
 
         duplicates = [n for n in mother_names_ccdecays if n in mother_names_decays]
@@ -754,7 +756,7 @@ The 'CDecay' definition(s) will be ignored ..."""
         # match name -> position in list self._parsed_decays
         name2treepos = {
             t.children[0].children[0].value: i
-            for i, t in enumerate(self._parsed_decays)  # type: ignore[arg-type]
+            for i, t in enumerate(self._parsed_decays)
         }
 
         trees_to_conjugate = []
@@ -762,7 +764,7 @@ The 'CDecay' definition(s) will be ignored ..."""
         for ccname in mother_names_ccdecays:
             name = find_charge_conjugate_match(ccname, dict_cc_names)
             try:
-                match = self._parsed_decays[name2treepos[name]]  # type: ignore[index]
+                match = self._parsed_decays[name2treepos[name]]
                 trees_to_conjugate.append(match)
             except Exception:
                 misses.append(ccname)
@@ -795,7 +797,7 @@ Skipping creation of charge-conjugate decay Tree."""
                 ChargeConjugateReplacement(charge_conj_defs=dict_cc_names).visit(t)
 
         # ... and add all these charge-conjugate decays to the list of decays!
-        self._parsed_decays.extend(cdecays)  # type: ignore[union-attr]
+        self._parsed_decays.extend(cdecays)
         self._decay_modes_index = None
 
     def _check_parsing(self) -> None:
@@ -825,9 +827,10 @@ All but the first occurrence will be discarded/removed ...""".format(
             warnings.warn(msg, stacklevel=2)
 
             # Rebuild the list keeping only the first occurrence of each name
+            assert self._parsed_decays is not None
             seen: set[str] = set()
             kept = []
-            for tree in self._parsed_decays:  # type: ignore[union-attr]
+            for tree in self._parsed_decays:
                 val = tree.children[0].children[0].value
                 if val in seen:
                     continue
@@ -840,16 +843,18 @@ All but the first occurrence will be discarded/removed ...""".format(
     def number_of_decays(self) -> int:
         """Return the number of particle decays defined in the parsed .dec file."""
         self._check_parsing()
+        assert self._parsed_decays is not None
 
-        return len(self._parsed_decays)  # type: ignore[arg-type]
+        return len(self._parsed_decays)
 
     def list_decay_mother_names(self) -> list[str | Any]:
         """
         Return a list of all decay mother names found in the parsed decay file.
         """
         self._check_parsing()
+        assert self._parsed_decays is not None
 
-        return [get_decay_mother_name(d) for d in self._parsed_decays]  # type: ignore[union-attr]
+        return [get_decay_mother_name(d) for d in self._parsed_decays]
 
     def _find_decay_modes(self, mother: str) -> tuple[Any, ...]:
         """
@@ -862,12 +867,13 @@ All but the first occurrence will be discarded/removed ...""".format(
             Input mother particle name.
         """
         self._check_parsing()
+        assert self._parsed_decays is not None
 
         if self._decay_modes_index is None:
             # Build the index once; later lookups are O(1). The index is
             # invalidated (reset to None) whenever self._parsed_decays changes.
             index: dict[str, tuple[Any, ...]] = {}
-            for decay_Tree in self._parsed_decays:  # type: ignore[union-attr]
+            for decay_Tree in self._parsed_decays:
                 name = get_decay_mother_name(decay_Tree)
                 # Keep the first occurrence, mirroring _find_decay_modes' old
                 # behavior of returning the first matching decay Tree.

--- a/src/decaylanguage/decay/decay.py
+++ b/src/decaylanguage/decay/decay.py
@@ -11,7 +11,7 @@ from collections import Counter
 from collections.abc import Collection, Iterator, Sequence
 from copy import deepcopy
 from itertools import product
-from typing import Any, TypedDict
+from typing import Any, NoReturn, TypedDict
 
 from particle import PDGID, ParticleNotFound
 from particle.converters import EvtGenName2PDGIDBiMap
@@ -88,7 +88,7 @@ class DaughtersDict(Counter[str]):
         super().__init__(iterable, **kwds)
 
     @classmethod
-    def fromkeys(cls, iterable, v=None):  # type: ignore[no-untyped-def]
+    def fromkeys(cls, iterable: Any, v: Any = None) -> NoReturn:
         # ==> Comment copied from Counter.fromkeys():
         # There is no equivalent method for counters because the semantics
         # would be ambiguous in cases such as Counter.fromkeys('aaabbc', v=2).

--- a/src/decaylanguage/decay/viewer.py
+++ b/src/decaylanguage/decay/viewer.py
@@ -180,15 +180,17 @@ class DecayChainViewer:
             for idm in range(n_decaymodes):
                 _list_parts = subchain[idm]["fs"]
                 _bf = subchain[idm]["bf"]
-                _effective_bf = effective_bf * float(_bf)  # type: ignore[arg-type]
-                if _has_no_subdecay(_list_parts):  # type: ignore[arg-type]
-                    _ref = new_node_no_subchain(_list_parts, _effective_bf)  # type: ignore[arg-type]
+                assert isinstance(_list_parts, list)
+                assert isinstance(_bf, (int, float))
+                _effective_bf = effective_bf * float(_bf)
+                if _has_no_subdecay(_list_parts):
+                    _ref = new_node_no_subchain(_list_parts, _effective_bf)
                     if link_pos is None:
                         self.graph.edge(top_node, _ref, label=str(_bf))
                     else:
                         self.graph.edge(f"{top_node}:p{link_pos}", _ref, label=str(_bf))
                 else:
-                    _ref_1 = new_node_with_subchain(_list_parts)  # type: ignore[arg-type]
+                    _ref_1 = new_node_with_subchain(_list_parts)
                     edge_label = str(_bf)
                     if link_pos is None:
                         self.graph.edge(top_node, _ref_1, label=edge_label)
@@ -198,7 +200,7 @@ class DecayChainViewer:
                             _ref_1,
                             label=edge_label,
                         )
-                    for i, _p in enumerate(_list_parts):  # type: ignore[arg-type]
+                    for i, _p in enumerate(_list_parts):
                         if not isinstance(_p, str):
                             _k = next(iter(_p.keys()))
                             iterate_chain(
@@ -228,7 +230,7 @@ class DecayChainViewer:
         Return a string representation of the built graph in the DOT language.
         The function is a trivial shortcut for ``graphviz.Digraph.source``.
         """
-        return self.graph.source  # type: ignore[no-any-return]
+        return str(self.graph.source)
 
     def _instantiate_graph(
         self, **attrs: dict[str, bool | int | float | str]


### PR DESCRIPTION
Addressing an old issue.

:robot: _AI text below_ :robot:

Closes #435.

Reviewed every `# type: ignore` in the mypy-checked subsystems (`dec/`, `decay/`, `utils/`) and removed **21 of 34**, replacing each with a proper annotation or a real runtime guard instead of a silenced error.

## Changes

**`dec/dec.py` (15 removed)**
- `_dec_file` retyped to `str | None` (declared once before the `if`), dropping the `[assignment]` ignore.
- `_parsed_decays` retyped from `Any | None` → `list[Tree] | None`. The 12 `union-attr` / `arg-type` / `index` ignores across `parse`, `_add_decays_to_be_copied`, `_add_charge_conjugate_decays`, `_check_parsed_decays`, `number_of_decays`, `list_decay_mother_names`, and `_find_decay_modes` are replaced by `assert self._parsed_decays is not None`. This is the heart of the issue's concern — those ignores silently hid the `None` (called-before-parse) case; the asserts turn it into a clear failure.
- `grammar()` now asserts `self._grammar is not None`, matching the existing pattern in the neighbouring `grammar_info()`.

**`decay/decay.py` (1 removed)**
- `DaughtersDict.fromkeys` annotated as `(cls, iterable: Any, v: Any = None) -> NoReturn`.

**`decay/viewer.py` (5 removed)**
- `to_string()` returns `str(self.graph.source)`.
- The 4 `[arg-type]` ignores in `iterate_chain` are gone after asserting the chain-dict value types.

## Deliberately kept (13)

Inherent to untyped third-party code or intentional behaviour, not maskable real bugs:
- `decay.py` — `[override]` on `DaughtersDict.__add__` / `__sub__` (narrowing `other` to `Self` is intentional and incompatible with `Counter`'s signature).
- `dec.py` — 3× `[misc]` on subclassing lark's untyped `Transformer` / `Visitor`.
- `dec.py` — `[operator]` (particle width) and `[union-attr]` (jetset regex match) — both inside `try/except` that intentionally handles the `None` case (the latter documented "will throw an error if match is None").
- TypedDict / `Sequence` narrowing spots (`decay.py:422,747,984`, `dec.py:1050,1219`, `viewer.py:256`) where a fix would require widening shared type definitions with cascading risk.

## Verification
- `prek -a --quiet` clean (incl. mypy via the CI hook config, where lark is untyped)
- `pytest`: 332 passed, 1 skipped
