### PR TITLE
docs: surface recently added features in the README (#366)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 * Utilities submodule:
   - Fixed a bug in `split()` where a trailing comma was not handled correctly (e.g. `split("a,")` returned `["a,"]` instead of `["a", ""]`).
   - Fixed `filter_lines()` to collect matched lines and residuals in a single pass instead of running the regex twice per line.
+* Documentation:
+  - Expanded the README to cover recently added, Flavour-Physics-oriented features: inspecting decay modes (`list_decay_modes`, `print_decay_modes`, `expand_decay_modes`), pruning decay chains via `build_decay_chains(..., minimum_effective_bf=...)` and annotating them with `DecayChainViewer(..., show_effective_bf=True)`, and text-based decay-chain tools (`to_string`, `print_as_tree`, `flatten`, `DaughtersDict` arithmetic and charge conjugation).
 * Dependencies:
   - Moved `numpy`, `pandas` and `plumbum` into an optional `decaylanguage[modeling]` extra; they are only needed by the `modeling` subpackage and the command-line interface. Core `.dec` parsing and decay-chain functionality no longer pull them in.
 * CI and tests:

--- a/README.md
+++ b/README.md
@@ -132,6 +132,29 @@ dfp = DecFileParser.from_string(s)
 dfp.parse()
 ```
 
+#### Inspecting decay modes
+
+The decay modes of any mother particle can be listed or pretty-printed.
+Branching fractions can optionally be normalised (so they sum to 1) or
+rescaled, and the list can be sorted in ascending order:
+
+```python
+# List of decay modes, each as a list of daughter names
+dfp.list_decay_modes('pi0')
+
+# Pretty print, here with branching fractions normalised to unity
+dfp.print_decay_modes('pi0', normalize=True)
+```
+
+The fully expanded list of decay descriptors of a particle, with every
+sub-decay resolved down to final states, is available via
+`expand_decay_modes` (this also reverts any aliases back to the original
+EvtGen names):
+
+```python
+dfp.expand_decay_modes('D*+')
+```
+
 #### Advanced usage
 
 The list of `.dec` file decay models known to the package can be inspected via
@@ -170,6 +193,23 @@ DecayChainViewer(d)  # works in a notebook
 ```
 
 ![DecayChain D*](https://raw.githubusercontent.com/scikit-hep/decaylanguage/main/images/DecayChain_Dst_stable-D0-and-D+.png)
+
+Real-life decay files easily produce decay chains with a very large number of
+sub-decays. The `minimum_effective_bf` argument of `build_decay_chains` prunes
+the chains whose effective branching fraction (the product of branching
+fractions from the mother down to the final states) falls below a threshold,
+keeping only the dominant paths:
+
+```python
+d = dfp.build_decay_chains('D*+', minimum_effective_bf=1e-4)
+```
+
+`DecayChainViewer` can in turn annotate each node with its effective branching
+fraction:
+
+```python
+DecayChainViewer(d, show_effective_bf=True)
+```
 
 The actual graph is available as
 
@@ -218,6 +258,41 @@ representation understood by `DecayChainViewer`, as see above:
 
 ```python
 DecayChainViewer(dc.to_dict())
+```
+
+Even without graphviz, a decay chain can be inspected on the terminal,
+either as a one-line descriptor or as an ASCII tree:
+
+```python
+>>> print(dc.to_string())
+D0 -> (K_S0 -> pi+ pi-) (pi0 -> gamma gamma)
+>>> dc.print_as_tree()
+D0
++--> K_S0
+|    +--> pi+
+|    +--> pi-
++--> pi0
+     +--> gamma
+     +--> gamma
+```
+
+Intermediate, decaying particles can be collapsed onto their final states with
+`flatten`, optionally treating some particles as stable:
+
+```python
+>>> dc.flatten().to_string()
+'D0 -> gamma gamma pi+ pi-'
+```
+
+Final states are easily manipulated as multisets via `DaughtersDict`, which
+supports addition, subtraction and charge conjugation:
+
+```python
+>>> from decaylanguage import DaughtersDict
+>>> (DaughtersDict('K+ K- pi0') + DaughtersDict('pi+ pi-')).to_string()
+'K+ K- pi+ pi- pi0'
+>>> DaughtersDict('K+ pi-').charge_conjugate().to_string()
+'K- pi+'
 ```
 
 The fact that 2 representations of particle decay chains are provided ensures


### PR DESCRIPTION
Addressing an old issue.

:robot: _AI text below_ :robot:

Closes #366.

At the moment several user-facing "goodies" of particular interest to Flavour Physics experiments are only known to insiders. This PR documents them in the README, grouped into the existing sections rather than adding new top-level structure.

## README additions

- **Inspecting decay modes** (new subsection under *Parse decay files*) — `list_decay_modes`, `print_decay_modes` (with `normalize` / `scale` / `ascending`), and `expand_decay_modes`.
- **Visualize decay files** — `build_decay_chains(..., minimum_effective_bf=...)` to prune negligible decay paths, and `DecayChainViewer(..., show_effective_bf=True)` to annotate nodes (both added in 0.20.4).
- **Universal representation** — `DecayChain.to_string()`, `print_as_tree()`, `flatten()`, plus `DaughtersDict` arithmetic (`+` / `-`) and `charge_conjugate()`.

## Notes

- Every new code example was run against the installed package and its output verified (one was corrected: the `pi0 -> gamma gamma` sub-decay expands in `to_string` / `print_as_tree` / `flatten`).
- Scoped to genuinely user-facing features. Lower-level introspection methods (`dict_aliases`, `dict_lineshape_settings`, `get_particle_property_definitions`, ...) were intentionally left for the ReadTheDocs API reference to keep the README a quick-start. Happy to add a short introspection paragraph if broader coverage is preferred.
- `CHANGELOG.md` updated with a Documentation entry under *Unreleased*.

`prek -a` passes on the changed files.