### PR TITLE
Add a pre-commit-hook for decay file validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
     - uses: j178/prek-action@v2
       with:
         extra-args: --all-files --hook-stage manual
+    - name: Test published pre-commit hook
+      run: >-
+        uvx pre-commit try-repo . decaylanguage-validate
+        --files tests/data/minimalistic.dec
     - name: PyLint
       run: uvx nox -s pylint -- --output-format=github
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,12 +45,6 @@ repos:
     language: pygrep
     entry: PyBind|Numpy|Cmake|CCache|Github|PyTest
     exclude: .pre-commit-config.yaml
-  - id: decaylanguage-validate
-    name: Validate EvtGen decay files
-    language: system
-    entry: uv run decaylanguage-validate
-    files: '^(src/decaylanguage/data/.*\.DEC|tests/data/.*\.dec)$'
-    exclude: '^tests/data/(duplicate-decays|test_Xicc2XicPiPi|test_custom_decay_model|test_issue90)\.dec$'
 
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: "v1.10.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,13 @@ repos:
     language: pygrep
     entry: PyBind|Numpy|Cmake|CCache|Github|PyTest
     exclude: .pre-commit-config.yaml
+  - id: decaylanguage-validate
+    name: Validate EvtGen decay files
+    language: python
+    entry: decaylanguage-validate
+    additional_dependencies: [.]
+    files: '^(src/decaylanguage/data/.*\.DEC|tests/data/.*\.dec)$'
+    exclude: '^tests/data/(duplicate-decays|test_Xicc2XicPiPi|test_custom_decay_model|test_issue90)\.dec$'
 
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: "v1.10.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,9 +47,8 @@ repos:
     exclude: .pre-commit-config.yaml
   - id: decaylanguage-validate
     name: Validate EvtGen decay files
-    language: python
-    entry: decaylanguage-validate
-    additional_dependencies: [.]
+    language: system
+    entry: uv run decaylanguage-validate
     files: '^(src/decaylanguage/data/.*\.DEC|tests/data/.*\.dec)$'
     exclude: '^tests/data/(duplicate-decays|test_Xicc2XicPiPi|test_custom_decay_model|test_issue90)\.dec$'
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 ci:
   autoupdate_commit_msg: "chore: update pre-commit hooks"
   autofix_commit_msg: "style: pre-commit fixes"
+  skip: [decaylanguage-validate]
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -42,9 +43,8 @@ repos:
   hooks:
   - id: decaylanguage-validate
     name: Validate bundled EvtGen decay files
-    entry: decaylanguage-validate
-    language: python
-    additional_dependencies: [.]
+    entry: uv run decaylanguage-validate
+    language: system
     files: '(?i:\.dec)$'
     args: [--ignore=DLW]
     exclude: '^tests/data/(?:models/|test_custom_decay_model\.dec$|test_issue90\.dec$)'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,13 @@ repos:
 
 - repo: local
   hooks:
+  - id: decaylanguage-validate
+    name: Validate bundled EvtGen decay files
+    entry: decaylanguage-validate
+    language: python
+    files: '(?i:\.dec)$'
+    args: [--ignore=DLW]
+    exclude: '^tests/data/(?:models/|test_custom_decay_model\.dec$|test_issue90\.dec$)'
   - id: disallow-caps
     name: Disallow improper capitalization
     language: pygrep

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,7 @@ repos:
     name: Validate bundled EvtGen decay files
     entry: decaylanguage-validate
     language: python
+    additional_dependencies: [.]
     files: '(?i:\.dec)$'
     args: [--ignore=DLW]
     exclude: '^tests/data/(?:models/|test_custom_decay_model\.dec$|test_issue90\.dec$)'

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: decaylanguage-validate
+  name: Validate EvtGen decay files
+  description: Validate .dec decay files with decaylanguage.DecFileParser.
+  entry: decaylanguage-validate
+  language: python
+  files: '\.(dec|DEC)$'

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,4 +3,4 @@
   description: Validate .dec decay files with decaylanguage.DecFileParser.
   entry: decaylanguage-validate
   language: python
-  files: '\.(dec|DEC)$'
+  files: '(?i:\.dec)$'

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,7 +1,0 @@
-
-Authors
-=======
-
-* Henry Fredrick Schreiner III - https://iscinumpy.gitlab.io
-* Eduardo Rodrigues - https://github.com/eduardo-rodrigues/
-* Jan Wagner - https://github.com/jpwgnr

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,3 +4,4 @@ Authors
 
 * Henry Fredrick Schreiner III - https://iscinumpy.gitlab.io
 * Eduardo Rodrigues - https://github.com/eduardo-rodrigues/
+* Jan Wagner - https://github.com/jpwgnr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
-## Version 1.0.0 (2026-06-25)
+## Unreleased
 
 * Parsing of decay files (aka .dec files):
   - Added `decaylanguage-validate` and a pre-commit hook for validating
     EvtGen `.dec` files with selectable diagnostic codes.
+* CI and tests:
+  - Added repository dogfooding and a downstream-style installation test for
+    the published decay-file pre-commit hook.
+
+## Version 1.0.0 (2026-06-25)
+
+* Parsing of decay files (aka .dec files):
   - Performance improvements in `DecFileParser`, with caching and lazily-built indexing where possible.
   - A couple of fixes related to the decay file parser.
   - Various improvements to the code, for more robustness.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
   - Added `decaylanguage-validate` and a pre-commit hook for validating
     EvtGen `.dec` files with selectable diagnostic codes.
 * CI and tests:
-  - Added repository dogfooding and a downstream-style installation test for
-    the published decay-file pre-commit hook.
+  - Added validation of this repository's own decay files and a
+    downstream-style installation test for the published decay-file pre-commit
+    hook.
 
 ## Version 1.0.0 (2026-06-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Version 1.0.0 (2026-06-25)
 
 * Parsing of decay files (aka .dec files):
+  - Added `decaylanguage-validate` and a pre-commit hook for validating
+    EvtGen `.dec` files with selectable diagnostic codes.
   - Performance improvements in `DecFileParser`, with caching and lazily-built indexing where possible.
   - A couple of fixes related to the decay file parser.
   - Various improvements to the code, for more robustness.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Parsing of decay files (aka .dec files):
-  - Added `decaylanguage-validate` and a pre-commit hook for validating
+  - Added the `decaylanguage-validate` script and a pre-commit hook for validating
     EvtGen `.dec` files with selectable diagnostic codes.
 * CI and tests:
   - Added validation of this repository's own decay files and a

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -82,3 +82,22 @@ Tips
 To run a subset of tests::
 
     nox -s tests-3.9 -- -k test_myfeature
+
+Decay file pre-commit hook
+--------------------------
+
+Downstream projects can validate EvtGen ``.dec`` files with the packaged
+pre-commit hook::
+
+    - repo: https://github.com/scikit-hep/decaylanguage
+      rev: <version>
+      hooks:
+      - id: decaylanguage-validate
+
+The hook reports selectable diagnostic codes. Experiments can ignore exact
+codes or whole code families, for example::
+
+    - id: decaylanguage-validate
+      args: ["--ignore=DLW004"]
+
+Use ``decaylanguage-validate --list-diagnostics`` to list the current codes.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -81,22 +81,3 @@ Tips
 To run a subset of tests::
 
     nox -s tests-3.9 -- -k test_myfeature
-
-Decay file pre-commit hook
---------------------------
-
-Downstream projects can validate EvtGen ``.dec`` files with the packaged
-pre-commit hook::
-
-    - repo: https://github.com/scikit-hep/decaylanguage
-      rev: <version>
-      hooks:
-      - id: decaylanguage-validate
-
-The hook reports selectable diagnostic codes. Experiments can ignore exact
-codes or whole code families, for example::
-
-    - id: decaylanguage-validate
-      args: ["--ignore=DLW004"]
-
-Use ``decaylanguage-validate --list-diagnostics`` to list the current codes.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -72,7 +72,6 @@ For merging, you should:
 1. Include passing tests (run ``nox``) [1]_.
 2. Update documentation when there's new API, functionality etc.
 3. Add a note to ``CHANGELOG.md`` about the changes.
-4. Add yourself to ``AUTHORS.rst``.
 
 .. [1] If you don't have all the necessary python versions available locally, you can run a specific nox session with  ``nox -s tests-3.9``, for example. GitHub Actions will run all the tests whenever a pull request is made, so testing all versions of Python locally is usually not necessary.
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ Just run the following:
 pip install decaylanguage
 ```
 
-The amplitude `modeling` subpackage and the command-line interface need a few
-extra dependencies (NumPy, pandas and plumbum). Install them with:
+The amplitude `modeling` subpackage and the AmpGen-to-GooFit command-line
+interface need a few extra dependencies (NumPy, pandas and plumbum). Install
+them with:
 
 ```bash
 pip install "decaylanguage[modeling]"
@@ -178,6 +179,73 @@ dfp.parse()
 
 This being said, please do submit a pull request to add new models,
 if you spot missing ones ...
+
+#### Validating decay files
+
+Decay files can be validated from the command line:
+
+```bash
+decaylanguage-validate my-decay-file.dec
+decaylanguage-validate path/to/decfiles-directory
+```
+
+The validator is also available as a pre-commit hook for downstream projects:
+
+```yaml
+- repo: https://github.com/scikit-hep/decaylanguage
+  rev: <version>
+  hooks:
+  - id: decaylanguage-validate
+```
+
+Diagnostics use stable codes, which can be disabled per experiment policy. For
+example, LHCb-style files that intentionally rely on unmatched `CDecay` source
+decays can ignore `DLW004`:
+
+```yaml
+- id: decaylanguage-validate
+  args: ["--ignore=DLW004"]
+```
+
+Run `decaylanguage-validate --list-diagnostics` to list the currently available
+codes.
+
+Available diagnostics:
+
+| Code | Name | Meaning |
+| --- | --- | --- |
+| `DLP001` | `parse-error` | The file could not be parsed by `DecFileParser`. |
+| `DLW001` | `duplicate-decay` | A particle has multiple `Decay` blocks; only the first is retained. |
+| `DLW002` | `missing-copydecay-source` | A `CopyDecay` statement references a missing `Decay` source. |
+| `DLW003` | `duplicate-cdecay` | A particle is defined with both `Decay` and `CDecay`; `CDecay` is ignored. |
+| `DLW004` | `missing-cdecay-source` | A `CDecay` statement has no corresponding `Decay` source. |
+| `DLW005` | `self-conjugate-cdecay` | A `CDecay` statement targets a self-conjugate particle. |
+| `DLW999` | `parser-warning` | An otherwise unclassified warning was emitted by `DecFileParser`. |
+
+When the hook finds a problem, pre-commit prints the validator output. A parser
+error includes the source line and column pointer:
+
+```text
+Validate EvtGen decay files..............................................Failed
+- hook id: decaylanguage-validate
+- exit code: 1
+
+DecayLanguage: 1 diagnostic(s) in 1 file(s)
+tests/data/broken.dec:13:68: DLP001 parse-error: UnexpectedToken: Unexpected token Token('SIGNED_NUMBER', '2') at line 13, column 68.
+       13: 0.000044342 Upsilon pi0     pi0                             VVPIPI;2 #[Reconstructed PDG2011]
+                                                                             ^
+summary: DLP001=1
+```
+
+Parser warnings are shorter:
+
+```text
+tests/data/example.dec: DLW004 missing-cdecay-source: missing Decay source for CDecay: anti-B0sig
+summary: DLW004=1
+```
+
+By default, the validator prints up to 100 diagnostics and then summarizes the
+rest. Use `--max-diagnostics=0` to print every diagnostic.
 
 ### Visualize decay files
 

--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ dfp.parse()
 This being said, please do submit a pull request to add new models,
 if you spot missing ones ...
 
-#### Validating decay files
+#### Validating decay files, and package pre-commit hook
 
-Decay files can be validated from the command line:
+Decay files can be validated from the command line with the following script:
 
 ```bash
 decaylanguage-validate my-decay-file.dec

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ pip install decaylanguage
 ```
 
 The amplitude `modeling` subpackage and the AmpGen-to-GooFit command-line
-interface need a few extra dependencies (NumPy, pandas and plumbum). Install
-them with:
+interface need a few extra dependencies (NumPy, pandas and plumbum).
+Install them with:
 
 ```bash
 pip install "decaylanguage[modeling]"

--- a/README.md
+++ b/README.md
@@ -189,6 +189,13 @@ decaylanguage-validate my-decay-file.dec
 decaylanguage-validate path/to/decfiles-directory
 ```
 
+Experiment-specific decay models can be enabled by repeating
+`--additional-decay-model` as needed:
+
+```bash
+decaylanguage-validate --additional-decay-model=MYMODEL my-decay-file.dec
+```
+
 The validator is also available as a pre-commit hook for downstream projects:
 
 ```yaml
@@ -214,7 +221,7 @@ Available diagnostics:
 
 | Code | Name | Meaning |
 | --- | --- | --- |
-| `DLP001` | `parse-error` | The file could not be parsed by `DecFileParser`. |
+| `DLP001` | `parse-error` | The file could not be read or parsed by `DecFileParser`. |
 | `DLW001` | `duplicate-decay` | A particle has multiple `Decay` blocks; only the first is retained. |
 | `DLW002` | `missing-copydecay-source` | A `CopyDecay` statement references a missing `Decay` source. |
 | `DLW003` | `duplicate-cdecay` | A particle is defined with both `Decay` and `CDecay`; `CDecay` is ignored. |
@@ -233,7 +240,7 @@ Validate EvtGen decay files..............................................Failed
 DecayLanguage: 1 diagnostic(s) in 1 file(s)
 tests/data/broken.dec:13:68: DLP001 parse-error: UnexpectedToken: Unexpected token Token('SIGNED_NUMBER', '2') at line 13, column 68.
        13: 0.000044342 Upsilon pi0     pi0                             VVPIPI;2 #[Reconstructed PDG2011]
-                                                                             ^
+                                                                              ^
 summary: DLP001=1
 ```
 

--- a/docs/api/dec.rst
+++ b/docs/api/dec.rst
@@ -4,3 +4,9 @@ Decay file parser — :mod:`decaylanguage.dec`
 .. automodule:: decaylanguage.dec.dec
    :members:
    :undoc-members:
+
+Decay file validation — :mod:`decaylanguage.dec.validate`
+---------------------------------------------------------
+
+.. automodule:: decaylanguage.dec.validate
+   :members:

--- a/docs/development/authors.rst
+++ b/docs/development/authors.rst
@@ -1,1 +1,0 @@
-.. include:: ../../AUTHORS.rst

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -7,4 +7,3 @@ Development
 
    changelog
    contributing
-   authors

--- a/docs/examples/decfile_parsing.rst
+++ b/docs/examples/decfile_parsing.rst
@@ -44,4 +44,89 @@ Charge conjugation
 By default, charge-conjugated decays are automatically included. This behavior
 can be controlled at parse time.
 
+Command-line validation
+-----------------------
+
+EvtGen ``.dec`` files can be validated without writing Python code:
+
+.. code-block:: bash
+
+   decaylanguage-validate my-decay-file.dec
+   decaylanguage-validate path/to/decfiles-directory
+
+The validator reports stable diagnostic codes. Exact codes or code families can
+be disabled, which lets experiments choose their own pre-commit policy:
+
+.. code-block:: bash
+
+   decaylanguage-validate --ignore=DLW004 my-decay-file.dec
+
+Use ``decaylanguage-validate --list-diagnostics`` to inspect the currently
+available diagnostics.
+
+Available diagnostics:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Code
+     - Name
+     - Meaning
+   * - ``DLP001``
+     - ``parse-error``
+     - The file could not be parsed by ``DecFileParser``.
+   * - ``DLW001``
+     - ``duplicate-decay``
+     - A particle has multiple ``Decay`` blocks; only the first is retained.
+   * - ``DLW002``
+     - ``missing-copydecay-source``
+     - A ``CopyDecay`` statement references a missing ``Decay`` source.
+   * - ``DLW003``
+     - ``duplicate-cdecay``
+     - A particle is defined with both ``Decay`` and ``CDecay``; ``CDecay`` is ignored.
+   * - ``DLW004``
+     - ``missing-cdecay-source``
+     - A ``CDecay`` statement has no corresponding ``Decay`` source.
+   * - ``DLW005``
+     - ``self-conjugate-cdecay``
+     - A ``CDecay`` statement targets a self-conjugate particle.
+   * - ``DLW999``
+     - ``parser-warning``
+     - An otherwise unclassified warning was emitted by ``DecFileParser``.
+
+When run through pre-commit, failures include the validator output. Parser
+errors include the source location and a pointer:
+
+.. code-block:: text
+
+   Validate EvtGen decay files..............................................Failed
+   - hook id: decaylanguage-validate
+   - exit code: 1
+
+   DecayLanguage: 1 diagnostic(s) in 1 file(s)
+   tests/data/broken.dec:13:68: DLP001 parse-error: UnexpectedToken: Unexpected token Token('SIGNED_NUMBER', '2') at line 13, column 68.
+          13: 0.000044342 Upsilon pi0     pi0                             VVPIPI;2 #[Reconstructed PDG2011]
+                                                                                ^
+   summary: DLP001=1
+
+Parser warnings are reported more compactly:
+
+.. code-block:: text
+
+   tests/data/example.dec: DLW004 missing-cdecay-source: missing Decay source for CDecay: anti-B0sig
+   summary: DLW004=1
+
+By default, at most 100 diagnostics are printed before the remaining diagnostics
+are summarized. Pass ``--max-diagnostics=0`` to print every diagnostic.
+
+Downstream projects can use the packaged pre-commit hook:
+
+.. code-block:: yaml
+
+   - repo: https://github.com/scikit-hep/decaylanguage
+     rev: <version>
+     hooks:
+     - id: decaylanguage-validate
+       args: ["--ignore=DLW004"]
+
 For more detailed examples, see the :doc:`/examples/notebooks/index` section.

--- a/docs/examples/decfile_parsing.rst
+++ b/docs/examples/decfile_parsing.rst
@@ -65,7 +65,7 @@ Experiment-specific decay models can be enabled by repeating
    decaylanguage-validate --additional-decay-model=MYMODEL my-decay-file.dec
 
 The validator reports stable diagnostic codes. Exact codes or code families can
-be disabled, which lets experiments choose their own pre-commit policy:
+be disabled, which lets experiments choose their own pre-commit hence validation policy:
 
 .. code-block:: bash
 

--- a/docs/examples/decfile_parsing.rst
+++ b/docs/examples/decfile_parsing.rst
@@ -46,6 +46,8 @@ can be controlled at parse time.
 
 For more detailed examples, see the :doc:`/examples/notebooks/index` section.
 
+.. _decfile-command-line-validation:
+
 Command-line validation
 -----------------------
 

--- a/docs/examples/decfile_parsing.rst
+++ b/docs/examples/decfile_parsing.rst
@@ -59,7 +59,7 @@ with a provided script:
    decaylanguage-validate my-decay-file.dec
    decaylanguage-validate path/to/decfiles-directory
 
-Experiment-specific decay models can be enabled by repeating
+Experiment-specific and decay models not yet available in the package can be enabled by repeating
 ``--additional-decay-model`` as needed:
 
 .. code-block:: bash

--- a/docs/examples/decfile_parsing.rst
+++ b/docs/examples/decfile_parsing.rst
@@ -65,7 +65,7 @@ Experiment-specific decay models can be enabled by repeating
    decaylanguage-validate --additional-decay-model=MYMODEL my-decay-file.dec
 
 The validator reports stable diagnostic codes. Exact codes or code families can
-be disabled, which lets experiments choose their own pre-commit hence validation policy:
+be disabled, which lets experiments choose their own validation policy:
 
 .. code-block:: bash
 
@@ -102,17 +102,12 @@ available diagnostics, which are the following:
      - ``parser-warning``
      - An otherwise unclassified warning was emitted by ``DecFileParser``.
 
-When run through pre-commit, failures include the validator output. Parser
-errors include the source location and a pointer:
+Parser errors include the source location and a pointer:
 
 .. code-block:: text
 
-   Validate EvtGen decay files..............................................Failed
-   - hook id: decaylanguage-validate
-   - exit code: 1
-
    DecayLanguage: 1 diagnostic(s) in 1 file(s)
-   tests/data/broken.dec:13:68: DLP001 parse-error: UnexpectedToken: Unexpected token Token('SIGNED_NUMBER', '2') at line 13, column 68.
+   tests/data/test_issue90.dec:13:68: DLP001 parse-error: UnexpectedToken: Unexpected token Token('SIGNED_NUMBER', '2') at line 13, column 68.
           13: 0.000044342 Upsilon pi0     pi0                             VVPIPI;2 #[Reconstructed PDG2011]
                                                                                  ^
    summary: DLP001=1
@@ -121,8 +116,10 @@ Parser warnings are reported more compactly:
 
 .. code-block:: text
 
-   tests/data/example.dec: DLW004 missing-cdecay-source: missing Decay source for CDecay: anti-B0sig
-   summary: DLW004=1
+   DecayLanguage: 2 diagnostic(s) in 1 file(s)
+   tests/data/duplicate-decays.dec: DLW001 duplicate-decay: duplicate Decay block(s): Sigma(1775)0; later definitions ignored
+   tests/data/duplicate-decays.dec: DLW003 duplicate-cdecay: both Decay and CDecay defined: anti-Sigma(1775)0; CDecay ignored
+   summary: DLW001=1, DLW003=1
 
 By default, at most 100 diagnostics are printed before the remaining diagnostics
 are summarized. Pass ``--max-diagnostics=0`` to print every diagnostic.

--- a/docs/examples/decfile_parsing.rst
+++ b/docs/examples/decfile_parsing.rst
@@ -47,7 +47,8 @@ can be controlled at parse time.
 Command-line validation
 -----------------------
 
-EvtGen ``.dec`` files can be validated without writing Python code:
+EvtGen ``.dec`` files can be validated without writing Python code
+with a provided script:
 
 .. code-block:: bash
 
@@ -69,9 +70,7 @@ be disabled, which lets experiments choose their own pre-commit policy:
    decaylanguage-validate --ignore=DLW004 my-decay-file.dec
 
 Use ``decaylanguage-validate --list-diagnostics`` to inspect the currently
-available diagnostics.
-
-Available diagnostics:
+available diagnostics, which are the following:
 
 .. list-table::
    :header-rows: 1

--- a/docs/examples/decfile_parsing.rst
+++ b/docs/examples/decfile_parsing.rst
@@ -66,12 +66,14 @@ Experiment-specific decay models can be enabled by repeating
 
    decaylanguage-validate --additional-decay-model=MYMODEL my-decay-file.dec
 
-The validator reports stable diagnostic codes. Exact codes or code families can
-be disabled, which lets experiments choose their own validation policy:
+The validator reports stable diagnostic codes. Exact codes such as ``DLW004``
+or code families such as ``DLW`` can be disabled, which lets experiments choose
+their own validation policy:
 
 .. code-block:: bash
 
    decaylanguage-validate --ignore=DLW004 my-decay-file.dec
+   decaylanguage-validate --ignore=DLW my-decay-file.dec
 
 Use ``decaylanguage-validate --list-diagnostics`` to inspect the currently
 available diagnostics, which are the following:
@@ -146,6 +148,13 @@ experiments can ignore exact diagnostic codes or whole code families:
 
    - id: decaylanguage-validate
      args: ["--ignore=DLW004"]
+
+To ignore a whole diagnostic family, use the family prefix:
+
+.. code-block:: yaml
+
+   - id: decaylanguage-validate
+     args: ["--ignore=DLW"]
 
 Use ``decaylanguage-validate --list-diagnostics`` to list the available
 diagnostics.

--- a/docs/examples/decfile_parsing.rst
+++ b/docs/examples/decfile_parsing.rst
@@ -124,12 +124,26 @@ Parser warnings are reported more compactly:
 By default, at most 100 diagnostics are printed before the remaining diagnostics
 are summarized. Pass ``--max-diagnostics=0`` to print every diagnostic.
 
-Downstream projects can use the packaged pre-commit hook:
+Pre-commit hook
+^^^^^^^^^^^^^^^
+
+Downstream projects can run the same validator automatically with the packaged
+pre-commit hook:
 
 .. code-block:: yaml
 
    - repo: https://github.com/scikit-hep/decaylanguage
      rev: <version>
      hooks:
-     - id: decaylanguage-validate
-       args: ["--ignore=DLW004"]
+       - id: decaylanguage-validate
+
+The hook accepts the same options as the command-line validator. For example,
+experiments can ignore exact diagnostic codes or whole code families:
+
+.. code-block:: yaml
+
+   - id: decaylanguage-validate
+     args: ["--ignore=DLW004"]
+
+Use ``decaylanguage-validate --list-diagnostics`` to list the available
+diagnostics.

--- a/docs/examples/decfile_parsing.rst
+++ b/docs/examples/decfile_parsing.rst
@@ -44,6 +44,8 @@ Charge conjugation
 By default, charge-conjugated decays are automatically included. This behavior
 can be controlled at parse time.
 
+For more detailed examples, see the :doc:`/examples/notebooks/index` section.
+
 Command-line validation
 -----------------------
 
@@ -134,5 +136,3 @@ Downstream projects can use the packaged pre-commit hook:
      hooks:
      - id: decaylanguage-validate
        args: ["--ignore=DLW004"]
-
-For more detailed examples, see the :doc:`/examples/notebooks/index` section.

--- a/docs/examples/decfile_parsing.rst
+++ b/docs/examples/decfile_parsing.rst
@@ -54,6 +54,13 @@ EvtGen ``.dec`` files can be validated without writing Python code:
    decaylanguage-validate my-decay-file.dec
    decaylanguage-validate path/to/decfiles-directory
 
+Experiment-specific decay models can be enabled by repeating
+``--additional-decay-model`` as needed:
+
+.. code-block:: bash
+
+   decaylanguage-validate --additional-decay-model=MYMODEL my-decay-file.dec
+
 The validator reports stable diagnostic codes. Exact codes or code families can
 be disabled, which lets experiments choose their own pre-commit policy:
 
@@ -74,7 +81,7 @@ Available diagnostics:
      - Meaning
    * - ``DLP001``
      - ``parse-error``
-     - The file could not be parsed by ``DecFileParser``.
+     - The file could not be read or parsed by ``DecFileParser``.
    * - ``DLW001``
      - ``duplicate-decay``
      - A particle has multiple ``Decay`` blocks; only the first is retained.
@@ -106,7 +113,7 @@ errors include the source location and a pointer:
    DecayLanguage: 1 diagnostic(s) in 1 file(s)
    tests/data/broken.dec:13:68: DLP001 parse-error: UnexpectedToken: Unexpected token Token('SIGNED_NUMBER', '2') at line 13, column 68.
           13: 0.000044342 Upsilon pi0     pi0                             VVPIPI;2 #[Reconstructed PDG2011]
-                                                                                ^
+                                                                                 ^
    summary: DLP001=1
 
 Parser warnings are reported more compactly:

--- a/docs/getting_started/quickstart.rst
+++ b/docs/getting_started/quickstart.rst
@@ -25,6 +25,24 @@ Use :class:`~decaylanguage.dec.dec.DecFileParser` to parse EvtGen-format ``.dec`
 
 See :doc:`/examples/decfile_parsing` for more details.
 
+Validate ``.dec`` files from the command line:
+
+.. code-block:: bash
+
+   decaylanguage-validate my_decays.dec
+   decaylanguage-validate path/to/decfiles-directory
+
+Use ``decaylanguage-validate --list-diagnostics`` to list selectable
+diagnostic codes. Downstream pre-commit hooks can disable experiment-specific
+codes with options such as ``--ignore=DLW004``.
+
+On failure, pre-commit shows output such as:
+
+.. code-block:: text
+
+   tests/data/example.dec: DLW004 missing-cdecay-source: missing Decay source for CDecay: anti-B0sig
+   summary: DLW004=1
+
 Building and visualizing decay chains
 -------------------------------------
 

--- a/docs/getting_started/quickstart.rst
+++ b/docs/getting_started/quickstart.rst
@@ -32,16 +32,18 @@ Validate ``.dec`` files from the command line:
    decaylanguage-validate my_decays.dec
    decaylanguage-validate path/to/decfiles-directory
 
-Use ``decaylanguage-validate --list-diagnostics`` to list selectable
-diagnostic codes. Downstream pre-commit hooks can disable experiment-specific
-codes with options such as ``--ignore=DLW004``.
-
-On failure, pre-commit shows output such as:
+On failure, the validator prints output such as:
 
 .. code-block:: text
 
-   tests/data/example.dec: DLW004 missing-cdecay-source: missing Decay source for CDecay: anti-B0sig
-   summary: DLW004=1
+   DecayLanguage: 2 diagnostic(s) in 1 file(s)
+   tests/data/duplicate-decays.dec: DLW001 duplicate-decay: duplicate Decay block(s): Sigma(1775)0; later definitions ignored
+   tests/data/duplicate-decays.dec: DLW003 duplicate-cdecay: both Decay and CDecay defined: anti-Sigma(1775)0; CDecay ignored
+   summary: DLW001=1, DLW003=1
+
+Use ``decaylanguage-validate --list-diagnostics`` to list the available
+diagnostics. For diagnostic options and the packaged pre-commit hook, see
+:ref:`the detailed validation guide <decfile-command-line-validation>`.
 
 Building and visualizing decay chains
 -------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,9 @@ test = [
 [project.urls]
 Homepage = "https://github.com/scikit-hep/decaylanguage"
 
+[project.scripts]
+decaylanguage-validate = "decaylanguage.dec.validate:main"
+
 
 [tool.hatch]
 version.source = "vcs"

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -71,6 +71,32 @@ class DecayNotFound(RuntimeError):
     pass
 
 
+class DecFileWarning(UserWarning):
+    """Warning emitted while interpreting a parsed decay file."""
+
+    code: str
+
+
+class DuplicateDecayWarning(DecFileWarning):
+    code = "DLW001"
+
+
+class MissingCopyDecaySourceWarning(DecFileWarning):
+    code = "DLW002"
+
+
+class DuplicateCDecayWarning(DecFileWarning):
+    code = "DLW003"
+
+
+class MissingCDecaySourceWarning(DecFileWarning):
+    code = "DLW004"
+
+
+class SelfConjugateCDecayWarning(DecFileWarning):
+    code = "DLW005"
+
+
 @cache
 def _build_lark_parser(
     grammar: str,
@@ -688,7 +714,7 @@ class DecFileParser:
             msg = """\nCorresponding 'Decay' statement for 'CopyDecay' statement(s) of following particle(s) not found:\n{}.
 Skipping creation of these copied decay trees.""".format("\n".join(misses))
 
-            warnings.warn(msg, stacklevel=2)
+            warnings.warn(msg, MissingCopyDecaySourceWarning, stacklevel=2)
 
         # Actually add all these copied decays to the list of decays!
         self._parsed_decays.extend(copied_decays)
@@ -734,7 +760,7 @@ Skipping creation of these copied decay trees.""".format("\n".join(misses))
             str_duplicates = ", ".join(d for d in duplicates)
             msg = f"""The following particles are defined in the input .dec file with both 'Decay' and 'CDecay': {str_duplicates}!
 The 'CDecay' definition(s) will be ignored ..."""
-            warnings.warn(msg, stacklevel=2)
+            warnings.warn(msg, DuplicateCDecayWarning, stacklevel=2)
 
         # If that's the case, proceed using the decay definitions specified
         # via the 'Decay' statement, hence discard/remove the definition
@@ -773,7 +799,7 @@ The 'CDecay' definition(s) will be ignored ..."""
 Skipping creation of these charge-conjugate decay trees.""".format(
                 "\n".join(m for m in misses)
             )
-            warnings.warn(msg, stacklevel=2)
+            warnings.warn(msg, MissingCDecaySourceWarning, stacklevel=2)
 
         cdecays = [copy.deepcopy(tree) for tree in trees_to_conjugate]
 
@@ -786,7 +812,7 @@ Skipping creation of these charge-conjugate decay trees.""".format(
                 if Particle.from_evtgen_name(mname).is_self_conjugate:
                     msg = f"""Found 'CDecay' statement for self-conjugate particle {mname}. This is a bug!
 Skipping creation of charge-conjugate decay Tree."""
-                    warnings.warn(msg, stacklevel=2)
+                    warnings.warn(msg, SelfConjugateCDecayWarning, stacklevel=2)
                     return False
                 return True
             except Exception:
@@ -824,7 +850,7 @@ All but the first occurrence will be discarded/removed ...""".format(
                 ", ".join(duplicates)
             )
 
-            warnings.warn(msg, stacklevel=2)
+            warnings.warn(msg, DuplicateDecayWarning, stacklevel=2)
 
             # Rebuild the list keeping only the first occurrence of each name
             assert self._parsed_decays is not None

--- a/src/decaylanguage/dec/validate.py
+++ b/src/decaylanguage/dec/validate.py
@@ -1,0 +1,443 @@
+# Copyright (c) 2018-2026, Eduardo Rodrigues and Henry Schreiner.
+#
+# Distributed under the 3-clause BSD license, see accompanying file LICENSE
+# or https://github.com/scikit-hep/decaylanguage for details.
+
+"""Command-line validation for EvtGen ``.dec`` files."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import warnings
+from collections import Counter
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from .dec import DecFileParser
+
+
+@dataclass(frozen=True)
+class DiagnosticRule:
+    """A selectable validation diagnostic."""
+
+    code: str
+    name: str
+    description: str
+    pattern: re.Pattern[str] | None = None
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    """One validation finding for a decay file."""
+
+    code: str
+    name: str
+    path: Path
+    message: str
+    line: int | None = None
+    column: int | None = None
+    source_line: str | None = None
+
+
+DLP001 = DiagnosticRule(
+    "DLP001",
+    "parse-error",
+    "The file could not be parsed by DecFileParser.",
+)
+DLW001 = DiagnosticRule(
+    "DLW001",
+    "duplicate-decay",
+    "A particle has multiple Decay blocks; only the first is retained.",
+    re.compile(
+        r"The following particle\(s\) is\(are\) redefined in the input \.dec file "
+        r"with 'Decay': .* All but the first occurrence will be discarded/removed "
+        r"\.\.\."
+    ),
+)
+DLW002 = DiagnosticRule(
+    "DLW002",
+    "missing-copydecay-source",
+    "A CopyDecay statement references a missing Decay source.",
+    re.compile(
+        r"Corresponding 'Decay' statement for 'CopyDecay' statement\(s\).* "
+        r"Skipping creation of these copied decay trees\."
+    ),
+)
+DLW003 = DiagnosticRule(
+    "DLW003",
+    "duplicate-cdecay",
+    "A particle is defined with both Decay and CDecay; CDecay is ignored.",
+    re.compile(
+        r"The following particles are defined in the input \.dec file with both "
+        r"'Decay' and 'CDecay': .* The 'CDecay' definition\(s\) will be ignored "
+        r"\.\.\."
+    ),
+)
+DLW004 = DiagnosticRule(
+    "DLW004",
+    "missing-cdecay-source",
+    "A CDecay statement has no corresponding Decay source.",
+    re.compile(
+        r"Corresponding 'Decay' statement for 'CDecay' statement\(s\).* "
+        r"Skipping creation of these charge-conjugate decay trees\."
+    ),
+)
+DLW005 = DiagnosticRule(
+    "DLW005",
+    "self-conjugate-cdecay",
+    "A CDecay statement targets a self-conjugate particle.",
+    re.compile(
+        r"Found 'CDecay' statement for self-conjugate particle .* "
+        r"Skipping creation of charge-conjugate decay Tree\."
+    ),
+)
+DLW999 = DiagnosticRule(
+    "DLW999",
+    "parser-warning",
+    "An otherwise unclassified warning was emitted by DecFileParser.",
+)
+
+DIAGNOSTIC_RULES = (DLP001, DLW001, DLW002, DLW003, DLW004, DLW005, DLW999)
+_RULES_BY_CODE = {rule.code: rule for rule in DIAGNOSTIC_RULES}
+_DEFAULT_MAX_DIAGNOSTICS = 100
+
+
+class Style:
+    def __init__(self, enabled: bool) -> None:
+        self.enabled = enabled
+
+    def color(self, text: str, code: str) -> str:
+        if not self.enabled:
+            return text
+        return f"\033[{code}m{text}\033[0m"
+
+    def fail(self, text: str) -> str:
+        return self.color(text, "31")
+
+    def ok(self, text: str) -> str:
+        return self.color(text, "32")
+
+    def bold(self, text: str) -> str:
+        return self.color(text, "1")
+
+    def muted(self, text: str) -> str:
+        return self.color(text, "2")
+
+
+def validate_files(
+    paths: Iterable[Path],
+    *,
+    ignore: Iterable[str] = (),
+    additional_decay_models: Iterable[str] = (),
+) -> list[Diagnostic]:
+    """Validate decay files and return non-ignored diagnostics."""
+
+    ignored = tuple(ignore)
+    diagnostics: list[Diagnostic] = []
+    for path in _iter_decay_files(paths):
+        diagnostics.extend(
+            diagnostic
+            for diagnostic in _validate_file(path, additional_decay_models)
+            if not _is_ignored(diagnostic.code, ignored)
+        )
+    return diagnostics
+
+
+def _iter_decay_files(paths: Iterable[Path]) -> Iterable[Path]:
+    for path in paths:
+        if path.is_dir():
+            yield from sorted(
+                item for item in path.rglob("*") if item.suffix.lower() == ".dec"
+            )
+        else:
+            yield path
+
+
+def _validate_file(
+    path: Path,
+    additional_decay_models: Iterable[str],
+) -> list[Diagnostic]:
+    caught_warnings: list[warnings.WarningMessage]
+    try:
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter("always")
+            parser = DecFileParser(path)
+            parser.load_additional_decay_models(*additional_decay_models)
+            parser.parse()
+    except Exception as exc:
+        return [_diagnostic_from_exception(path, exc)]
+
+    return [_diagnostic_from_warning(path, warning) for warning in caught_warnings]
+
+
+def _diagnostic_from_exception(path: Path, exc: Exception) -> Diagnostic:
+    line = getattr(exc, "line", None)
+    column = getattr(exc, "column", None)
+    source_line = None
+    if isinstance(line, int):
+        try:
+            source_line = path.read_text(encoding="utf_8").splitlines()[line - 1]
+        except Exception:
+            source_line = None
+
+    return Diagnostic(
+        code=DLP001.code,
+        name=DLP001.name,
+        path=path,
+        message=f"{exc.__class__.__name__}: {str(exc).splitlines()[0]}",
+        line=line if isinstance(line, int) else None,
+        column=column if isinstance(column, int) else None,
+        source_line=source_line,
+    )
+
+
+def _diagnostic_from_warning(
+    path: Path,
+    warning: warnings.WarningMessage,
+) -> Diagnostic:
+    message = _normalize_warning_message(warning)
+    rule = next(
+        (
+            candidate
+            for candidate in DIAGNOSTIC_RULES
+            if candidate.pattern is not None and candidate.pattern.fullmatch(message)
+        ),
+        DLW999,
+    )
+    return Diagnostic(
+        code=rule.code,
+        name=rule.name,
+        path=path,
+        message=_compact_warning_message(rule, message),
+    )
+
+
+def _normalize_warning_message(warning: warnings.WarningMessage) -> str:
+    return " ".join(str(warning.message).split())
+
+
+def _compact_warning_message(rule: DiagnosticRule, message: str) -> str:
+    if rule is DLW001:
+        particles = _search_message(message, r"with 'Decay': (?P<particles>.*?)!")
+        if particles is not None:
+            return f"duplicate Decay block(s): {particles}; later definitions ignored"
+    if rule is DLW002:
+        particles = _search_message(message, r"not found: (?P<particles>.*?)\.")
+        if particles is not None:
+            return f"missing Decay source for CopyDecay: {particles}"
+    if rule is DLW003:
+        particles = _search_message(message, r"'CDecay': (?P<particles>.*?)!")
+        if particles is not None:
+            return f"both Decay and CDecay defined: {particles}; CDecay ignored"
+    if rule is DLW004:
+        particles = _search_message(message, r"not found: (?P<particles>.*?)\.")
+        if particles is not None:
+            return f"missing Decay source for CDecay: {particles}"
+    if rule is DLW005:
+        particle = _search_message(
+            message,
+            r"self-conjugate particle (?P<particles>.*?)\.",
+        )
+        if particle is not None:
+            return f"CDecay targets self-conjugate particle: {particle}"
+    return message
+
+
+def _search_message(message: str, pattern: str) -> str | None:
+    match = re.search(pattern, message)
+    if match is None:
+        return None
+    return match.group("particles")
+
+
+def _is_ignored(code: str, ignored: Sequence[str]) -> bool:
+    return any(code == item or code.startswith(item) for item in ignored)
+
+
+def _validate_ignore_codes(codes: Iterable[str]) -> list[str]:
+    prefixes = {rule.code[:3] for rule in DIAGNOSTIC_RULES}
+    valid_codes = set(_RULES_BY_CODE)
+    invalid = [
+        code for code in codes if code not in valid_codes and code not in prefixes
+    ]
+    if invalid:
+        known = ", ".join(sorted(valid_codes | prefixes))
+        msg = f"unknown diagnostic code(s): {', '.join(invalid)}. Known codes: {known}"
+        raise SystemExit(msg)
+    return list(codes)
+
+
+def _use_color(color: str) -> bool:
+    if color == "always":
+        return True
+    if color == "never":
+        return False
+    return sys.stderr.isatty() and "NO_COLOR" not in os.environ
+
+
+def _print_diagnostics(
+    diagnostics: list[Diagnostic],
+    *,
+    files: Sequence[Path],
+    show_ok: bool,
+    color: str,
+    max_diagnostics: int,
+) -> None:
+    style = Style(_use_color(color))
+    if diagnostics:
+        shown_diagnostics = (
+            diagnostics if max_diagnostics == 0 else diagnostics[:max_diagnostics]
+        )
+        sys.stderr.write(
+            style.fail(
+                style.bold(
+                    f"DecayLanguage: {len(diagnostics)} diagnostic(s) in "
+                    f"{len({diagnostic.path for diagnostic in diagnostics})} file(s)"
+                )
+            )
+            + "\n"
+        )
+        for diagnostic in shown_diagnostics:
+            sys.stderr.write(
+                f"{_format_location(diagnostic)}: "
+                f"{style.fail(diagnostic.code)} "
+                f"{diagnostic.name}: {diagnostic.message}\n"
+            )
+            if diagnostic.line is not None and diagnostic.source_line is not None:
+                sys.stderr.write(
+                    style.muted(f"       {diagnostic.line}: {diagnostic.source_line}")
+                    + "\n"
+                )
+                if diagnostic.column is not None:
+                    pointer = " " * max(diagnostic.column - 1, 0) + "^"
+                    sys.stderr.write(style.muted(f"          {pointer}") + "\n")
+        hidden = len(diagnostics) - len(shown_diagnostics)
+        if hidden:
+            sys.stderr.write(
+                style.muted(
+                    f"... {hidden} additional diagnostic(s) hidden; "
+                    "use --max-diagnostics=0 to show all"
+                )
+                + "\n"
+            )
+        stats = ", ".join(
+            f"{code}={count}"
+            for code, count in sorted(Counter(d.code for d in diagnostics).items())
+        )
+        sys.stderr.write(style.muted(f"summary: {stats}") + "\n")
+        return
+
+    if show_ok:
+        sys.stderr.write(style.ok(f"DecayLanguage: {len(files)} file(s) passed") + "\n")
+
+
+def _format_location(diagnostic: Diagnostic) -> str:
+    parts = [_display_path(diagnostic.path)]
+    if diagnostic.line is not None:
+        parts.append(str(diagnostic.line))
+        if diagnostic.column is not None:
+            parts.append(str(diagnostic.column))
+    return ":".join(parts)
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return os.path.relpath(path)
+    except ValueError:
+        return str(path)
+
+
+def _print_rules() -> None:
+    for rule in DIAGNOSTIC_RULES:
+        sys.stdout.write(f"{rule.code} {rule.name}: {rule.description}\n")
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate EvtGen decay files with decaylanguage.DecFileParser.",
+    )
+    parser.add_argument(
+        "--ignore",
+        action="append",
+        default=[],
+        metavar="CODE",
+        help=(
+            "ignore a diagnostic code or code prefix, for example DLW004 or DLW; "
+            "may be used more than once"
+        ),
+    )
+    parser.add_argument(
+        "--additional-decay-model",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help="allow an experiment-specific EvtGen decay model name",
+    )
+    parser.add_argument(
+        "--show-ok",
+        action="store_true",
+        help="print a message when all files pass",
+    )
+    parser.add_argument(
+        "--max-diagnostics",
+        type=int,
+        default=_DEFAULT_MAX_DIAGNOSTICS,
+        metavar="N",
+        help=(
+            "maximum diagnostics to print before summarising; "
+            "use 0 to print all diagnostics"
+        ),
+    )
+    parser.add_argument(
+        "--color",
+        choices=("auto", "always", "never"),
+        default="auto",
+        help="control colored output",
+    )
+    parser.add_argument(
+        "--list-diagnostics",
+        action="store_true",
+        help="list available diagnostic codes and exit",
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        metavar="PATH",
+        help="decay files or directories containing .dec/.DEC files",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    if args.list_diagnostics:
+        _print_rules()
+        return 0
+    if not args.files:
+        raise SystemExit("at least one decay file must be provided")
+
+    ignored = _validate_ignore_codes(args.ignore)
+    if args.max_diagnostics < 0:
+        raise SystemExit("--max-diagnostics must be non-negative")
+    diagnostics = validate_files(
+        args.files,
+        ignore=ignored,
+        additional_decay_models=args.additional_decay_model,
+    )
+    _print_diagnostics(
+        diagnostics,
+        files=args.files,
+        show_ok=args.show_ok,
+        color=args.color,
+        max_diagnostics=args.max_diagnostics,
+    )
+    return 1 if diagnostics else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/decaylanguage/dec/validate.py
+++ b/src/decaylanguage/dec/validate.py
@@ -100,11 +100,11 @@ class Style:
     Helper class meant for internal use.
     """
 
-    def __init__(self, enabled: bool) -> None:
-        self.enabled = enabled
+    def __init__(self, use_color: bool) -> None:
+        self.use_color = use_color
 
     def color(self, text: str, code: str) -> str:
-        if not self.enabled:
+        if not self.use_color:
             return text
         return f"\033[{code}m{text}\033[0m"
 
@@ -166,6 +166,7 @@ def _validate_file(
         ]
     caught_warnings: list[warnings.WarningMessage]
     try:
+        # DecFileParser reports recoverable validation issues as warnings.
         with warnings.catch_warnings(record=True) as caught_warnings:
             warnings.simplefilter("always")
             parser = DecFileParser(path)
@@ -183,6 +184,8 @@ def _diagnostic_from_exception(path: Path, exc: Exception) -> Diagnostic:
     source_line = None
     if isinstance(line, int):
         try:
+            # Keep parse-error output useful even when the parser gives only
+            # location attributes on the exception.
             source_line = path.read_text(encoding="utf_8").splitlines()[line - 1]
         except Exception:
             source_line = None
@@ -224,6 +227,8 @@ def _normalize_warning_message(warning: warnings.WarningMessage) -> str:
 
 
 def _compact_warning_message(rule: DiagnosticRule, message: str) -> str:
+    # Warning text from DecFileParser is user-facing but verbose; keep the
+    # diagnostic stable by extracting only the particle names we need.
     if rule is DLW001:
         particles = _search_message(message, r"with 'Decay': (?P<particles>.*?)!")
         if particles is not None:
@@ -262,13 +267,13 @@ def _is_ignored(code: str, ignored: Sequence[str]) -> bool:
 
 
 def _validate_ignore_codes(codes: Iterable[str]) -> list[str]:
+    # Accept exact diagnostic codes and family prefixes such as "DLW".
     prefixes = {rule.code[:3] for rule in DIAGNOSTIC_RULES}
-    valid_codes = set(_RULES_BY_CODE)
     invalid = [
-        code for code in codes if code not in valid_codes and code not in prefixes
+        code for code in codes if code not in _RULES_BY_CODE and code not in prefixes
     ]
     if invalid:
-        known = ", ".join(sorted(valid_codes | prefixes))
+        known = ", ".join(sorted(_RULES_BY_CODE.keys() | prefixes))
         msg = f"unknown diagnostic code(s): {', '.join(invalid)}. Known codes: {known}"
         raise SystemExit(msg)
     return list(codes)
@@ -320,6 +325,8 @@ def _print_diagnostics(
                     source_before_column = diagnostic.source_line[
                         : max(diagnostic.column - 1, 0)
                     ]
+                    # Expand tabs before measuring so the caret aligns with
+                    # the rendered source line.
                     pointer = (
                         " " * len(source_prefix)
                         + " " * len(source_before_column.expandtabs())

--- a/src/decaylanguage/dec/validate.py
+++ b/src/decaylanguage/dec/validate.py
@@ -22,7 +22,11 @@ from .dec import DecFileParser, DecFileWarning
 
 @dataclass(frozen=True)
 class DiagnosticRule:
-    """A selectable validation diagnostic."""
+    """
+    A selectable EvtGen ``.dec`` file validation diagnostic.
+    
+    Helper class meant for internal use.
+    """
 
     code: str
     name: str
@@ -31,7 +35,11 @@ class DiagnosticRule:
 
 @dataclass(frozen=True)
 class Diagnostic:
-    """One validation finding for a decay file."""
+    """
+    One validation finding for an EvtGen ``.dec`` decay file.
+    
+    Helper class meant for internal use.
+    """
 
     code: str
     name: str
@@ -41,6 +49,8 @@ class Diagnostic:
     column: int | None = None
     source_line: str | None = None
 
+
+# The available validation diagnostic rules
 
 DLP001 = DiagnosticRule(
     "DLP001",
@@ -75,7 +85,7 @@ DLW005 = DiagnosticRule(
 DLW999 = DiagnosticRule(
     "DLW999",
     "parser-warning",
-    "An otherwise unclassified warning was emitted by DecFileParser.",
+    "An otherwise unclassified warning emitted by DecFileParser.",
 )
 
 DIAGNOSTIC_RULES = (DLP001, DLW001, DLW002, DLW003, DLW004, DLW005, DLW999)
@@ -84,6 +94,11 @@ _DEFAULT_MAX_DIAGNOSTICS = 100
 
 
 class Style:
+    """
+    Provide printing style for EvtGen ``.dec`` file validation diagnostics.
+    
+    Helper class meant for internal use.
+    """
     def __init__(self, enabled: bool) -> None:
         self.enabled = enabled
 
@@ -111,7 +126,7 @@ def validate_files(
     ignore: Iterable[str] = (),
     additional_decay_models: Iterable[str] = (),
 ) -> list[Diagnostic]:
-    """Validate decay files and return non-ignored diagnostics."""
+    """Validate EvtGen ``.dec`` decay files and return non-ignored diagnostics."""
 
     ignored = tuple(ignore)
     additional_models = tuple(additional_decay_models)
@@ -414,7 +429,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         _print_rules()
         return 0
     if not args.files:
-        raise SystemExit("at least one decay file must be provided")
+        raise SystemExit("at least one decay file must be provided!")
 
     ignored = _validate_ignore_codes(args.ignore)
     if args.max_diagnostics < 0:

--- a/src/decaylanguage/dec/validate.py
+++ b/src/decaylanguage/dec/validate.py
@@ -45,7 +45,7 @@ class Diagnostic:
 DLP001 = DiagnosticRule(
     "DLP001",
     "parse-error",
-    "The file could not be parsed by DecFileParser.",
+    "The file could not be read or parsed by DecFileParser.",
 )
 DLW001 = DiagnosticRule(
     "DLW001",

--- a/src/decaylanguage/dec/validate.py
+++ b/src/decaylanguage/dec/validate.py
@@ -17,7 +17,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from .dec import DecFileParser
+from .dec import DecFileParser, DecFileWarning
 
 
 @dataclass(frozen=True)
@@ -27,7 +27,6 @@ class DiagnosticRule:
     code: str
     name: str
     description: str
-    pattern: re.Pattern[str] | None = None
 
 
 @dataclass(frozen=True)
@@ -52,48 +51,26 @@ DLW001 = DiagnosticRule(
     "DLW001",
     "duplicate-decay",
     "A particle has multiple Decay blocks; only the first is retained.",
-    re.compile(
-        r"The following particle\(s\) is\(are\) redefined in the input \.dec file "
-        r"with 'Decay': .* All but the first occurrence will be discarded/removed "
-        r"\.\.\."
-    ),
 )
 DLW002 = DiagnosticRule(
     "DLW002",
     "missing-copydecay-source",
     "A CopyDecay statement references a missing Decay source.",
-    re.compile(
-        r"Corresponding 'Decay' statement for 'CopyDecay' statement\(s\).* "
-        r"Skipping creation of these copied decay trees\."
-    ),
 )
 DLW003 = DiagnosticRule(
     "DLW003",
     "duplicate-cdecay",
     "A particle is defined with both Decay and CDecay; CDecay is ignored.",
-    re.compile(
-        r"The following particles are defined in the input \.dec file with both "
-        r"'Decay' and 'CDecay': .* The 'CDecay' definition\(s\) will be ignored "
-        r"\.\.\."
-    ),
 )
 DLW004 = DiagnosticRule(
     "DLW004",
     "missing-cdecay-source",
     "A CDecay statement has no corresponding Decay source.",
-    re.compile(
-        r"Corresponding 'Decay' statement for 'CDecay' statement\(s\).* "
-        r"Skipping creation of these charge-conjugate decay trees\."
-    ),
 )
 DLW005 = DiagnosticRule(
     "DLW005",
     "self-conjugate-cdecay",
     "A CDecay statement targets a self-conjugate particle.",
-    re.compile(
-        r"Found 'CDecay' statement for self-conjugate particle .* "
-        r"Skipping creation of charge-conjugate decay Tree\."
-    ),
 )
 DLW999 = DiagnosticRule(
     "DLW999",
@@ -137,11 +114,12 @@ def validate_files(
     """Validate decay files and return non-ignored diagnostics."""
 
     ignored = tuple(ignore)
+    additional_models = tuple(additional_decay_models)
     diagnostics: list[Diagnostic] = []
     for path in _iter_decay_files(paths):
         diagnostics.extend(
             diagnostic
-            for diagnostic in _validate_file(path, additional_decay_models)
+            for diagnostic in _validate_file(path, additional_models)
             if not _is_ignored(diagnostic.code, ignored)
         )
     return diagnostics
@@ -161,6 +139,15 @@ def _validate_file(
     path: Path,
     additional_decay_models: Iterable[str],
 ) -> list[Diagnostic]:
+    if not path.is_file():
+        return [
+            Diagnostic(
+                code=DLP001.code,
+                name=DLP001.name,
+                path=path,
+                message="file does not exist or is not a regular file",
+            )
+        ]
     caught_warnings: list[warnings.WarningMessage]
     try:
         with warnings.catch_warnings(record=True) as caught_warnings:
@@ -200,14 +187,9 @@ def _diagnostic_from_warning(
     warning: warnings.WarningMessage,
 ) -> Diagnostic:
     message = _normalize_warning_message(warning)
-    rule = next(
-        (
-            candidate
-            for candidate in DIAGNOSTIC_RULES
-            if candidate.pattern is not None and candidate.pattern.fullmatch(message)
-        ),
-        DLW999,
-    )
+    category = warning.category
+    code = category.code if issubclass(category, DecFileWarning) else DLW999.code
+    rule = _RULES_BY_CODE.get(code, DLW999)
     return Diagnostic(
         code=rule.code,
         name=rule.name,

--- a/src/decaylanguage/dec/validate.py
+++ b/src/decaylanguage/dec/validate.py
@@ -24,7 +24,7 @@ from .dec import DecFileParser, DecFileWarning
 class DiagnosticRule:
     """
     A selectable EvtGen ``.dec`` file validation diagnostic.
-    
+
     Helper class meant for internal use.
     """
 
@@ -37,7 +37,7 @@ class DiagnosticRule:
 class Diagnostic:
     """
     One validation finding for an EvtGen ``.dec`` decay file.
-    
+
     Helper class meant for internal use.
     """
 
@@ -96,9 +96,10 @@ _DEFAULT_MAX_DIAGNOSTICS = 100
 class Style:
     """
     Provide printing style for EvtGen ``.dec`` file validation diagnostics.
-    
+
     Helper class meant for internal use.
     """
+
     def __init__(self, enabled: bool) -> None:
         self.enabled = enabled
 

--- a/src/decaylanguage/dec/validate.py
+++ b/src/decaylanguage/dec/validate.py
@@ -435,5 +435,5 @@ def main(argv: Sequence[str] | None = None) -> int:
     return 1 if diagnostics else 0
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())

--- a/src/decaylanguage/dec/validate.py
+++ b/src/decaylanguage/dec/validate.py
@@ -171,11 +171,16 @@ def _diagnostic_from_exception(path: Path, exc: Exception) -> Diagnostic:
         except Exception:
             source_line = None
 
+    message_lines = str(exc).strip().splitlines()
+    message = exc.__class__.__name__
+    if message_lines:
+        message += f": {message_lines[0]}"
+
     return Diagnostic(
         code=DLP001.code,
         name=DLP001.name,
         path=path,
-        message=f"{exc.__class__.__name__}: {str(exc).splitlines()[0]}",
+        message=message,
         line=line if isinstance(line, int) else None,
         column=column if isinstance(column, int) else None,
         source_line=source_line,
@@ -290,13 +295,21 @@ def _print_diagnostics(
                 f"{diagnostic.name}: {diagnostic.message}\n"
             )
             if diagnostic.line is not None and diagnostic.source_line is not None:
+                source_prefix = f"       {diagnostic.line}: "
+                expanded_source_line = diagnostic.source_line.expandtabs()
                 sys.stderr.write(
-                    style.muted(f"       {diagnostic.line}: {diagnostic.source_line}")
-                    + "\n"
+                    style.muted(f"{source_prefix}{expanded_source_line}") + "\n"
                 )
                 if diagnostic.column is not None:
-                    pointer = " " * max(diagnostic.column - 1, 0) + "^"
-                    sys.stderr.write(style.muted(f"          {pointer}") + "\n")
+                    source_before_column = diagnostic.source_line[
+                        : max(diagnostic.column - 1, 0)
+                    ]
+                    pointer = (
+                        " " * len(source_prefix)
+                        + " " * len(source_before_column.expandtabs())
+                        + "^"
+                    )
+                    sys.stderr.write(style.muted(pointer) + "\n")
         hidden = len(diagnostics) - len(shown_diagnostics)
         if hidden:
             sys.stderr.write(
@@ -406,14 +419,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     ignored = _validate_ignore_codes(args.ignore)
     if args.max_diagnostics < 0:
         raise SystemExit("--max-diagnostics must be non-negative")
+    files = list(_iter_decay_files(args.files))
     diagnostics = validate_files(
-        args.files,
+        files,
         ignore=ignored,
         additional_decay_models=args.additional_decay_model,
     )
     _print_diagnostics(
         diagnostics,
-        files=args.files,
+        files=files,
         show_ok=args.show_ok,
         color=args.color,
         max_diagnostics=args.max_diagnostics,

--- a/tests/dec/test_validate.py
+++ b/tests/dec/test_validate.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2018-2026, Eduardo Rodrigues and Henry Schreiner.
+#
+# Distributed under the 3-clause BSD license, see accompanying file LICENSE
+# or https://github.com/scikit-hep/decaylanguage for details.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from decaylanguage.dec.validate import main, validate_files
+
+DIR = Path(__file__).parent.resolve()
+
+
+def test_validate_files_reports_duplicate_decay() -> None:
+    diagnostics = validate_files([DIR / "../data/duplicate-decays.dec"])
+
+    assert [diagnostic.code for diagnostic in diagnostics] == ["DLW001", "DLW003"]
+    assert diagnostics[0].message.startswith("duplicate Decay block")
+
+
+def test_validate_files_can_ignore_exact_code() -> None:
+    diagnostics = validate_files(
+        [DIR / "../data/duplicate-decays.dec"],
+        ignore=["DLW001", "DLW003"],
+    )
+
+    assert diagnostics == []
+
+
+def test_validate_files_can_ignore_code_prefix() -> None:
+    diagnostics = validate_files(
+        [DIR / "../data/duplicate-decays.dec"],
+        ignore=["DLW"],
+    )
+
+    assert diagnostics == []
+
+
+def test_validate_files_accepts_directories() -> None:
+    diagnostics = validate_files(
+        [DIR / "../data"],
+        ignore=["DLW", "DLP"],
+    )
+
+    assert diagnostics == []
+
+
+def test_validate_files_reports_parse_errors(tmp_path: Path) -> None:
+    path = tmp_path / "broken.dec"
+    path.write_text(
+        """Decay pi0
+1.0 gamma gamma PHSP;
+""",
+        encoding="utf_8",
+    )
+
+    diagnostics = validate_files([path])
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].code == "DLP001"
+    assert diagnostics[0].line is not None
+
+
+def test_main_returns_failure_for_diagnostics() -> None:
+    assert main(["--color=never", str(DIR / "../data/duplicate-decays.dec")]) == 1
+
+
+def test_main_limits_displayed_diagnostics(capsys: pytest.CaptureFixture[str]) -> None:
+    assert (
+        main(
+            [
+                "--color=never",
+                "--max-diagnostics=1",
+                str(DIR / "../data/duplicate-decays.dec"),
+            ]
+        )
+        == 1
+    )
+
+    captured = capsys.readouterr()
+    assert "additional diagnostic(s) hidden" in captured.err
+    assert "summary: DLW001=1, DLW003=1" in captured.err
+
+
+def test_main_returns_success_for_ignored_diagnostics() -> None:
+    assert (
+        main(
+            [
+                "--color=never",
+                "--ignore=DLW001",
+                "--ignore=DLW003",
+                str(DIR / "../data/duplicate-decays.dec"),
+            ]
+        )
+        == 0
+    )
+
+
+def test_main_rejects_unknown_ignore_code() -> None:
+    with pytest.raises(SystemExit, match="unknown diagnostic code"):
+        main(["--ignore=NOPE", str(DIR / "../data/duplicate-decays.dec")])

--- a/tests/dec/test_validate.py
+++ b/tests/dec/test_validate.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 
 import warnings
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+import decaylanguage.dec.validate as validate_module
 from decaylanguage.dec.dec import (
     DuplicateCDecayWarning,
     DuplicateDecayWarning,
@@ -89,11 +91,43 @@ def test_warning_categories_map_to_diagnostics(
     assert diagnostic.message == compact_message
 
 
+def test_known_warning_with_unrecognized_message_is_not_rewritten() -> None:
+    message = "A future version of this warning with different wording."
+    warning = warnings.WarningMessage(
+        DuplicateDecayWarning(message), DuplicateDecayWarning, "test.dec", 1
+    )
+
+    diagnostic = _diagnostic_from_warning(Path("test.dec"), warning)
+
+    assert diagnostic.code == "DLW001"
+    assert diagnostic.message == message
+
+
 def test_validate_files_reports_duplicate_decay() -> None:
     diagnostics = validate_files([DIR / "../data/duplicate-decays.dec"])
 
     assert [diagnostic.code for diagnostic in diagnostics] == ["DLW001", "DLW003"]
     assert diagnostics[0].message.startswith("duplicate Decay block")
+
+
+def test_validate_files_reports_self_conjugate_cdecay(tmp_path: Path) -> None:
+    path = tmp_path / "self-conjugate-cdecay.dec"
+    path.write_text(
+        """Alias MyPi0 pi0
+ChargeConj MyPi0 pi0
+Decay pi0
+1.0 gamma gamma PHSP;
+Enddecay
+CDecay MyPi0
+End
+""",
+        encoding="utf_8",
+    )
+
+    diagnostics = validate_files([path])
+
+    assert [diagnostic.code for diagnostic in diagnostics] == ["DLW005"]
+    assert diagnostics[0].message == "CDecay targets self-conjugate particle: pi0"
 
 
 def test_validate_files_can_ignore_exact_code() -> None:
@@ -168,6 +202,24 @@ def test_validate_files_reports_missing_files(tmp_path: Path) -> None:
 
 def test_main_returns_failure_for_diagnostics() -> None:
     assert main(["--color=never", str(DIR / "../data/duplicate-decays.dec")]) == 1
+
+
+def test_main_can_force_colored_output(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["--color=always", str(DIR / "../data/duplicate-decays.dec")]) == 1
+
+    assert "\033[" in capsys.readouterr().err
+
+
+def test_automatic_color_detection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setattr(
+        validate_module.sys, "stderr", SimpleNamespace(isatty=lambda: True)
+    )
+
+    assert validate_module._use_color("auto") is True
+
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert validate_module._use_color("auto") is False
 
 
 def test_main_limits_displayed_diagnostics(capsys: pytest.CaptureFixture[str]) -> None:
@@ -274,3 +326,34 @@ def test_main_returns_success_for_ignored_diagnostics() -> None:
 def test_main_rejects_unknown_ignore_code() -> None:
     with pytest.raises(SystemExit, match="unknown diagnostic code"):
         main(["--ignore=NOPE", str(DIR / "../data/duplicate-decays.dec")])
+
+
+def test_main_lists_diagnostics(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["--list-diagnostics"]) == 0
+
+    output = capsys.readouterr().out
+    assert "DLP001 parse-error" in output
+    assert "DLW999 parser-warning" in output
+
+
+def test_main_rejects_missing_files_argument() -> None:
+    with pytest.raises(SystemExit, match="at least one decay file"):
+        main([])
+
+
+def test_main_rejects_negative_max_diagnostics() -> None:
+    with pytest.raises(SystemExit, match="must be non-negative"):
+        main(["--max-diagnostics=-1", "example.dec"])
+
+
+def test_display_path_handles_cross_drive_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = Path("D:/decays/example.dec")
+
+    def raise_value_error(_: Path) -> str:
+        raise ValueError
+
+    monkeypatch.setattr(validate_module.os.path, "relpath", raise_value_error)
+
+    assert validate_module._display_path(path) == str(path)

--- a/tests/dec/test_validate.py
+++ b/tests/dec/test_validate.py
@@ -5,13 +5,75 @@
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 import pytest
 
-from decaylanguage.dec.validate import main, validate_files
+from decaylanguage.dec.dec import (
+    DuplicateCDecayWarning,
+    DuplicateDecayWarning,
+    MissingCDecaySourceWarning,
+    MissingCopyDecaySourceWarning,
+    SelfConjugateCDecayWarning,
+)
+from decaylanguage.dec.validate import _diagnostic_from_warning, main, validate_files
 
 DIR = Path(__file__).parent.resolve()
+
+
+@pytest.mark.parametrize(
+    ("category", "message", "code", "compact_message"),
+    [
+        (
+            DuplicateDecayWarning,
+            "The following particle(s) is(are) redefined in the input .dec file "
+            "with 'Decay': D0! All but the first occurrence will be "
+            "discarded/removed ...",
+            "DLW001",
+            "duplicate Decay block(s): D0; later definitions ignored",
+        ),
+        (
+            MissingCopyDecaySourceWarning,
+            "Corresponding 'Decay' statement for 'CopyDecay' statement(s) of "
+            "following particle(s) not found: D0. Skipping creation of these "
+            "copied decay trees.",
+            "DLW002",
+            "missing Decay source for CopyDecay: D0",
+        ),
+        (
+            DuplicateCDecayWarning,
+            "The following particles are defined in the input .dec file with both "
+            "'Decay' and 'CDecay': D0! The 'CDecay' definition(s) will be ignored ...",
+            "DLW003",
+            "both Decay and CDecay defined: D0; CDecay ignored",
+        ),
+        (
+            MissingCDecaySourceWarning,
+            "Corresponding 'Decay' statement for 'CDecay' statement(s) of following "
+            "particle(s) not found: D0. Skipping creation of these charge-conjugate "
+            "decay trees.",
+            "DLW004",
+            "missing Decay source for CDecay: D0",
+        ),
+        (
+            SelfConjugateCDecayWarning,
+            "Found 'CDecay' statement for self-conjugate particle pi0. This is a bug! "
+            "Skipping creation of charge-conjugate decay Tree.",
+            "DLW005",
+            "CDecay targets self-conjugate particle: pi0",
+        ),
+    ],
+)
+def test_warning_categories_map_to_diagnostics(
+    category: type[Warning], message: str, code: str, compact_message: str
+) -> None:
+    warning = warnings.WarningMessage(category(message), category, "test.dec", 1)
+
+    diagnostic = _diagnostic_from_warning(Path("test.dec"), warning)
+
+    assert diagnostic.code == code
+    assert diagnostic.message == compact_message
 
 
 def test_validate_files_reports_duplicate_decay() -> None:
@@ -62,6 +124,14 @@ def test_validate_files_reports_parse_errors(tmp_path: Path) -> None:
     assert len(diagnostics) == 1
     assert diagnostics[0].code == "DLP001"
     assert diagnostics[0].line is not None
+
+
+def test_validate_files_reports_missing_files(tmp_path: Path) -> None:
+    diagnostics = validate_files([tmp_path / "missing.dec"])
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].code == "DLP001"
+    assert diagnostics[0].message == "file does not exist or is not a regular file"
 
 
 def test_main_returns_failure_for_diagnostics() -> None:

--- a/tests/dec/test_validate.py
+++ b/tests/dec/test_validate.py
@@ -200,8 +200,12 @@ def test_validate_files_reports_missing_files(tmp_path: Path) -> None:
     assert diagnostics[0].message == "file does not exist or is not a regular file"
 
 
-def test_main_returns_failure_for_diagnostics() -> None:
+def test_main_returns_failure_for_diagnostics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     assert main(["--color=never", str(DIR / "../data/duplicate-decays.dec")]) == 1
+
+    assert "\033[" not in capsys.readouterr().err
 
 
 def test_main_can_force_colored_output(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/dec/test_validate.py
+++ b/tests/dec/test_validate.py
@@ -70,6 +70,12 @@ DIR = Path(__file__).parent.resolve()
             "DLW005",
             "CDecay targets self-conjugate particle: pi0",
         ),
+        (
+            UserWarning,
+            "An unclassified parser warning.",
+            "DLW999",
+            "An unclassified parser warning.",
+        ),
     ],
 )
 def test_warning_categories_map_to_diagnostics(
@@ -112,6 +118,18 @@ def test_validate_files_accepts_directories() -> None:
     diagnostics = validate_files(
         [DIR / "../data"],
         ignore=["DLW", "DLP"],
+    )
+
+    assert diagnostics == []
+
+
+def test_validate_files_reuses_additional_decay_model_generator() -> None:
+    path = DIR / "../data/test_custom_decay_model.dec"
+    models = (model for model in ("CUSTOM_MODEL1", "CUSTOM_MODEL2"))
+
+    diagnostics = validate_files(
+        [path, path],
+        additional_decay_models=models,
     )
 
     assert diagnostics == []

--- a/tests/dec/test_validate.py
+++ b/tests/dec/test_validate.py
@@ -17,7 +17,14 @@ from decaylanguage.dec.dec import (
     MissingCopyDecaySourceWarning,
     SelfConjugateCDecayWarning,
 )
-from decaylanguage.dec.validate import _diagnostic_from_warning, main, validate_files
+from decaylanguage.dec.validate import (
+    Diagnostic,
+    _diagnostic_from_exception,
+    _diagnostic_from_warning,
+    _print_diagnostics,
+    main,
+    validate_files,
+)
 
 DIR = Path(__file__).parent.resolve()
 
@@ -126,6 +133,13 @@ def test_validate_files_reports_parse_errors(tmp_path: Path) -> None:
     assert diagnostics[0].line is not None
 
 
+@pytest.mark.parametrize("message", ["", "\n \t"])
+def test_diagnostic_from_exception_accepts_empty_message(message: str) -> None:
+    diagnostic = _diagnostic_from_exception(Path("broken.dec"), AssertionError(message))
+
+    assert diagnostic.message == "AssertionError"
+
+
 def test_validate_files_reports_missing_files(tmp_path: Path) -> None:
     diagnostics = validate_files([tmp_path / "missing.dec"])
 
@@ -153,6 +167,76 @@ def test_main_limits_displayed_diagnostics(capsys: pytest.CaptureFixture[str]) -
     captured = capsys.readouterr()
     assert "additional diagnostic(s) hidden" in captured.err
     assert "summary: DLW001=1, DLW003=1" in captured.err
+
+
+def test_print_diagnostics_aligns_column_pointer(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    diagnostic = Diagnostic(
+        code="DLP001",
+        name="parse-error",
+        path=Path("broken.dec"),
+        message="bad input",
+        line=12,
+        column=3,
+        source_line="abcdef",
+    )
+
+    _print_diagnostics(
+        [diagnostic],
+        files=[diagnostic.path],
+        show_ok=False,
+        color="never",
+        max_diagnostics=100,
+    )
+
+    lines = capsys.readouterr().err.splitlines()
+    source_line = next(line for line in lines if line.endswith("abcdef"))
+    pointer_line = next(line for line in lines if line.endswith("^"))
+    assert pointer_line.index("^") == source_line.index("c")
+
+
+def test_print_diagnostics_aligns_column_pointer_after_tab(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    diagnostic = Diagnostic(
+        code="DLP001",
+        name="parse-error",
+        path=Path("broken.dec"),
+        message="bad input",
+        line=1,
+        column=3,
+        source_line="a\tb",
+    )
+
+    _print_diagnostics(
+        [diagnostic],
+        files=[diagnostic.path],
+        show_ok=False,
+        color="never",
+        max_diagnostics=100,
+    )
+
+    lines = capsys.readouterr().err.splitlines()
+    source_line = next(line for line in lines if line.endswith("b"))
+    pointer_line = next(line for line in lines if line.endswith("^"))
+    assert "\t" not in source_line
+    assert pointer_line.index("^") == source_line.index("b")
+
+
+@pytest.mark.parametrize("number_of_files", [0, 2])
+def test_main_show_ok_counts_expanded_directory_files(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    number_of_files: int,
+) -> None:
+    for index in range(number_of_files):
+        (tmp_path / f"valid-{index}.dec").write_text("End\n", encoding="utf_8")
+
+    assert main(["--color=never", "--show-ok", str(tmp_path)]) == 0
+
+    captured = capsys.readouterr()
+    assert f"DecayLanguage: {number_of_files} file(s) passed" in captured.err
 
 
 def test_main_returns_success_for_ignored_diagnostics() -> None:


### PR DESCRIPTION
## Summary

Add a first-party `decaylanguage-validate` command and pre-commit hook for validating EvtGen `.dec` files with `DecFileParser`.

The validator reports stable diagnostic codes so downstream experiments can choose their own policy, for example ignoring LHCb-style unmatched `CDecay` source warnings with `--ignore=DLW004`.

## Changes

- Add `decaylanguage.dec.validate` with a CLI entry point exposed as `decaylanguage-validate`.
- Add `.pre-commit-hooks.yaml` so external repositories can use `id: decaylanguage-validate`.
- Add the validator to this repository's pre-commit config for bundled/test `.dec` files, excluding intentional negative fixtures.
- Add selectable diagnostics:
  - `DLP001` parse errors
  - `DLW001` duplicate `Decay` blocks
  - `DLW002` missing `CopyDecay` source
  - `DLW003` duplicate `Decay`/`CDecay`
  - `DLW004` missing `CDecay` source
  - `DLW005` self-conjugate `CDecay`
  - `DLW999` unclassified parser warnings
- Add compact pre-commit-style output with source pointers for parse errors, diagnostic summaries, and `--max-diagnostics`.
- Allow validating individual files or directories recursively.
- Document CLI usage, pre-commit configuration, ignore policy, and expected failure output.
- Add focused validator tests.

## Testing

```bash
uv run pytest tests/dec/test_validate.py -q
uv run ruff check src/decaylanguage/dec/validate.py tests/dec/test_validate.py
uv run ruff format --check src/decaylanguage/dec/validate.py tests/dec/test_validate.py
uv run --with mypy mypy src/decaylanguage/dec/validate.py
uv run pre-commit validate-config .pre-commit-config.yaml
uv run pre-commit validate-manifest .pre-commit-hooks.yaml
uv run pre-commit run decaylanguage-validate --all-files
```

Also tested on the local LHCb DecFiles checkout:

```bash
uv run decaylanguage-validate --ignore=DLW004 /Users/jpherdi/Documents/CERN_Software/DecFiles
```

This leaves `DLP001`, `DLW001`, and `DLW003` diagnostics after ignoring the expected LHCb-style `DLW004` findings.
