### PR TITLE
Prepare for major release 1.0.0 and dependencies updates to match those of Particle 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Miscellaneous - typing:
   - Reviewed and reduced `# type: ignore` comments across submodules.
 * CI and tests:
+  - Minor updates of tests for Particle 1.0.0
   - Several improvements, enhancements and clean_ups.
   - Removed dead `filterwarnings` ignore for PyArrow/pandas deprecation (pandas >=2.2.2 no longer emits it).
   - Trimmed mypy pre-commit hook's `additional_dependencies` to only what the covered code actually imports (`particle`, `hepunits`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,24 @@
 # Changelog
 
-## Unreleased
+## Version 1.0.0 (2026-06-25)
 
 * Parsing of decay files (aka .dec files):
-  - Various improvements to the code, for more robustness.
   - Performance improvements in `DecFileParser`, with caching and lazily-built indexing where possible.
   - A couple of fixes related to the decay file parser.
+  - Various improvements to the code, for more robustness.
   - Typing modernisations.
   - Code simplifications to various helper functions.
   - Updated the `known_decay_models` comment in `dec/enums.py` to reflect that
     the list is injected via `edit_terminals` rather than a static grammar terminal.
 * Universal representation of decay chains:
   - Added `DaughtersDict.__sub__`, returning a `DaughtersDict` (mirrors `__add__`).
-  - Fixed `DecayChain.from_dict` so it can read back its own `to_dict` output when the same particle appears more than once with an identical sub-decay (e.g. `eta -> pi0 pi0` with `pi0 -> gamma gamma`); genuinely conflicting redefinitions still raise.
-  - `DecayChainViewer` now uses a per-instance node counter, so rendering the same chain twice yields identical, reproducible DOT output.
-  - `DecayChainViewer` now HTML-escapes particle names in its fallback label path, producing valid DOT for names containing `&`, `<`, `>`.
+  - Fixed `DecayChain.from_dict` so it can read back its own `to_dict` output when the same particle
+    appears more than once with an identical sub-decay (e.g. `eta -> pi0 pi0` with `pi0 -> gamma gamma`);
+    genuinely conflicting redefinitions still raise.
+  - `DecayChainViewer` now uses a per-instance node counter,
+    so rendering the same chain twice yields identical, reproducible DOT output.
+  - `DecayChainViewer` now HTML-escapes particle names in its fallback label path,
+     producing valid DOT for names containing `&`, `<`, `>`.
   - Modernisations in `decay/` and `utils/`.
   - Other minor fixes.
 * Modeling submodule (`modeling/`):
@@ -22,13 +26,20 @@
   - Several AmpGen to GooFit conversion fixes (fix/free flags, polar-to-cartesian error propagation, spin factor mappings, state leakage, output formatting, and more).
   - Various other fixes and minor improvements.
 * Utilities submodule:
-  - Fixed a bug in `split()` where a trailing comma was not handled correctly (e.g. `split("a,")` returned `["a,"]` instead of `["a", ""]`).
-  - Fixed `filter_lines()` to collect matched lines and residuals in a single pass instead of running the regex twice per line.
+  - Fixed a bug in `split()` where a trailing comma was not handled correctly
+    (e.g. `split("a,")` returned `["a,"]` instead of `["a", ""]`).
+  - Fixed `filter_lines()` to collect matched lines and residuals in a single pass
+    instead of running the regex twice per line.
 * Documentation:
-  - Expanded the README to cover recently added, Flavour-Physics-oriented features: inspecting decay modes (`list_decay_modes`, `print_decay_modes`, `expand_decay_modes`), pruning decay chains via `build_decay_chains(..., minimum_effective_bf=...)` and annotating them with `DecayChainViewer(..., show_effective_bf=True)`, and text-based decay-chain tools (`to_string`, `print_as_tree`, `flatten`, `DaughtersDict` arithmetic and charge conjugation).
+  - Expanded the README to cover recently added, Flavour-Physics-oriented features:
+    inspecting decay modes (`list_decay_modes`, `print_decay_modes`, `expand_decay_modes`),
+    pruning decay chains via `build_decay_chains(..., minimum_effective_bf=...)`
+    and annotating them with `DecayChainViewer(..., show_effective_bf=True)`,
+    and text-based decay-chain tools (`to_string`, `print_as_tree`, `flatten`,
+    `DaughtersDict` arithmetic and charge conjugation).
 * Dependencies:
   - Moved `numpy`, `pandas` and `plumbum` into an optional `decaylanguage[modeling]` extra; they are only needed by the `modeling` subpackage and the command-line interface. Core `.dec` parsing and decay-chain functionality no longer pull them in.
-* Miscellaneous -typing:
+* Miscellaneous - typing:
   - Reviewed and reduced `# type: ignore` comments across submodules.
 * CI and tests:
   - Several improvements, enhancements and clean_ups.

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: decaylanguage_demo
 dependencies:
   - python>=3.10
-  - pandas>=1
+  - pandas>=2.0
   - attrs>=22.2.0
   - pip>=9
   - jupyterlab>=0.4

--- a/environment.yml
+++ b/environment.yml
@@ -1,16 +1,16 @@
 name: decaylanguage_demo
 dependencies:
-  - python>=3.9
+  - python>=3.10
   - pandas>=1
-  - attrs>=19.2
+  - attrs>=22.2.0
   - pip>=9
-  - jupyterlab>=0.35
+  - jupyterlab>=0.4
   - numpy>=1.19.3
   - graphviz>=0.12.0
   - plumbum>=1.7.0
   - lark>=1.0.0
   - RISE
   - hepunits>=2.4.0
-  - particle>=0.26.0
+  - particle>=1.0.0
   - pip:
     - .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "attrs>=19.2",
+    "attrs>=22.2.0",
     "graphviz>=0.12.0",
     "lark>=1.0.0",
     "particle>=1.0.0",
@@ -52,7 +52,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 modeling = [
     "numpy>=1.21.6",
-    "pandas>=1.4",
+    "pandas>=2.0",
     "plumbum>=1.7.0",
 ]
 
@@ -75,7 +75,7 @@ test = [
     "decaylanguage[modeling]",
     "pytest-benchmark>=5.2.0",
     "pytest-cov",
-    "pytest>=6",
+    "pytest>=7",
 ]
 
 [project.urls]
@@ -106,7 +106,7 @@ ignore_missing_imports = true
 
 
 [tool.pytest.ini_options]
-minversion = "6.0"
+minversion = "7.0"
 testpaths = ["tests"]
 addopts = [
     "-ra",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "attrs>=19.2",
     "graphviz>=0.12.0",
     "lark>=1.0.0",
-    "particle>=0.26.0",
+    "particle>=1.0.0",
     "hepunits>=2.4.0",
 ]
 dynamic = ["version"]

--- a/tests/dec/test_dec.py
+++ b/tests/dec/test_dec.py
@@ -198,7 +198,7 @@ def test_particle_property_definitions():
         "MyPhi": {"mass": 1.02, "width": 0.004},
         "rho0": {"mass": 0.8, "width": 0.2},
         "MyRho0": {"mass": 0.77, "width": 0.1474},
-        "chi_c0": {"mass": 3.42, "width": 0.0109},
+        "chi_c0": {"mass": 3.42, "width": 0.0124},
     }
 
 

--- a/tests/output/DtoKpipipi_v2.cu
+++ b/tests/output/DtoKpipipi_v2.cu
@@ -58,39 +58,39 @@ PseudoTensor:
   NonDefined:
 
 
- 0 D0[D]{K*(892)~0{K-,pi+},rho(770)0{pi+,pi-}}                            spinfactors: 2  L: 2 [0-2.0]
- 1 D0[D]{rho(1450)0{pi+,pi-},K*(892)~0{K-,pi+}}                           spinfactors: 2  L: 2 [0-2.0]
- 2 D0[P]{K*(892)~0{K-,pi+},rho(770)0{pi+,pi-}}                            spinfactors: 2  L: 1 [0-2.0]
- 3 D0[P]{rho(1450)0{pi+,pi-},K*(892)~0{K-,pi+}}                           spinfactors: 2  L: 1 [0-2.0]
- 4 D0{K(1)(1270)-[D;GSpline.EFF]{K*(892)~0{K-,pi+},pi-},pi+}              spinfactors: 2  L: 1.0 [1.0-1.0]
- 5 D0{K(1)(1270)-[GSpline.EFF]{K*(892)~0{K-,pi+},pi-},pi+}                spinfactors: 2  L: 1.0 [1.0-1.0]
- 6 D0{K(1)(1270)-[GSpline.EFF]{KPi20[FOCUS.Kpi]{K-,pi+},pi-},pi+}         spinfactors: 2  L: 1.0 [1.0-1.0]
- 7 D0{K(1)(1270)-[GSpline.EFF]{omega(782){pi+,pi-},K-},pi+}               spinfactors: 2  L: 1.0 [1.0-1.0]
- 8 D0{K(1)(1270)-[GSpline.EFF]{rho(1450)0{pi+,pi-},K-},pi+}               spinfactors: 2  L: 1.0 [1.0-1.0]
- 9 D0{K(1)(1270)-[GSpline.EFF]{rho(770)0{pi+,pi-},K-},pi+}                spinfactors: 2  L: 1.0 [1.0-1.0]
-10 D0{K(1)(1400)-{K*(892)~0{K-,pi+},pi-},pi+}                             spinfactors: 2  L: 1.0 [1.0-1.0]
-11 D0{K(1460)-[GSpline.EFF]{K*(892)~0{K-,pi+},pi-},pi+}                   spinfactors: 1  L: 0 [0-0.0]
-12 D0{K(1460)-[GSpline.EFF]{PiPi3[kMatrix.pole.0]{pi+,pi-},K-},pi+}       spinfactors: 1  L: 0 [0-0.0]
-13 D0{K(1460)-[GSpline.EFF]{PiPi3[kMatrix.pole.1]{pi+,pi-},K-},pi+}       spinfactors: 1  L: 0 [0-0.0]
-14 D0{K(1460)-[GSpline.EFF]{PiPi3[kMatrix.prod.1]{pi+,pi-},K-},pi+}       spinfactors: 1  L: 0 [0-0.0]
-15 D0{K(2)*(1430)-{K*(892)~0{K-,pi+},pi-},pi+}                            spinfactors: 2  L: 2.0 [2.0-2.0]
-16 D0{K*(892)~0{K-,pi+},PiPi1[kMatrix.pole.1]{pi+,pi-}}                   spinfactors: 2  L: 1.0 [1.0-1.0]
-17 D0{K*(892)~0{K-,pi+},PiPi1[kMatrix.prod.0]{pi+,pi-}}                   spinfactors: 2  L: 1.0 [1.0-1.0]
-18 D0{K*(892)~0{K-,pi+},rho(770)0{pi+,pi-}}                               spinfactors: 1  L: 0 [0-2.0]
-19 D0{KPi00[FOCUS.I32]{K-,pi+},PiPi0[kMatrix.pole.1]{pi+,pi-}}            spinfactors: 1  L: 0 [0-0.0]
-20 D0{KPi00[FOCUS.I32]{K-,pi+},PiPi0[kMatrix.prod.0]{pi+,pi-}}            spinfactors: 1  L: 0 [0-0.0]
-21 D0{KPi00[FOCUS.KEta]{K-,pi+},PiPi0[kMatrix.pole.1]{pi+,pi-}}           spinfactors: 1  L: 0 [0-0.0]
-22 D0{KPi00[FOCUS.KEta]{K-,pi+},PiPi0[kMatrix.prod.0]{pi+,pi-}}           spinfactors: 1  L: 0 [0-0.0]
-23 D0{KPi00[FOCUS.Kpi]{K-,pi+},PiPi0[kMatrix.pole.1]{pi+,pi-}}            spinfactors: 1  L: 0 [0-0.0]
-24 D0{KPi00[FOCUS.Kpi]{K-,pi+},PiPi0[kMatrix.prod.0]{pi+,pi-}}            spinfactors: 1  L: 0 [0-0.0]
-25 D0{a(1)(1260)+[D;GSpline.EFF]{rho(770)0{pi+,pi-},pi+},K-}              spinfactors: 2  L: 1.0 [1.0-1.0]
-26 D0{a(1)(1260)+[GSpline.EFF]{PiPi2[kMatrix.pole.0]{pi+,pi-},pi+},K-}    spinfactors: 2  L: 1.0 [1.0-1.0]
-27 D0{a(1)(1260)+[GSpline.EFF]{PiPi2[kMatrix.pole.1]{pi+,pi-},pi+},K-}    spinfactors: 2  L: 1.0 [1.0-1.0]
-28 D0{a(1)(1260)+[GSpline.EFF]{PiPi2[kMatrix.prod.0]{pi+,pi-},pi+},K-}    spinfactors: 2  L: 1.0 [1.0-1.0]
-29 D0{a(1)(1260)+[GSpline.EFF]{rho(770)0{pi+,pi-},pi+},K-}                spinfactors: 2  L: 1.0 [1.0-1.0]
-30 D0{rho(1450)0{pi+,pi-},K*(892)~0{K-,pi+}}                              spinfactors: 1  L: 0 [0-2.0]
-31 D0{rho(770)0{pi+,pi-},KPi10[FOCUS.I32]{K-,pi+}}                        spinfactors: 2  L: 1.0 [1.0-1.0]
-32 D0{rho(770)0{pi+,pi-},KPi10[FOCUS.Kpi]{K-,pi+}}                        spinfactors: 2  L: 1.0 [1.0-1.0]
+ 0 D0[D]{K*(892)~0{K-,pi+},rho(770)0{pi+,pi-}}                            spinfactors: 2  L: 2 [0-2]
+ 1 D0[D]{rho(1450)0{pi+,pi-},K*(892)~0{K-,pi+}}                           spinfactors: 2  L: 2 [0-2]
+ 2 D0[P]{K*(892)~0{K-,pi+},rho(770)0{pi+,pi-}}                            spinfactors: 2  L: 1 [0-2]
+ 3 D0[P]{rho(1450)0{pi+,pi-},K*(892)~0{K-,pi+}}                           spinfactors: 2  L: 1 [0-2]
+ 4 D0{K(1)(1270)-[D;GSpline.EFF]{K*(892)~0{K-,pi+},pi-},pi+}              spinfactors: 2  L: 1 [1-1]
+ 5 D0{K(1)(1270)-[GSpline.EFF]{K*(892)~0{K-,pi+},pi-},pi+}                spinfactors: 2  L: 1 [1-1]
+ 6 D0{K(1)(1270)-[GSpline.EFF]{KPi20[FOCUS.Kpi]{K-,pi+},pi-},pi+}         spinfactors: 2  L: 1 [1-1]
+ 7 D0{K(1)(1270)-[GSpline.EFF]{omega(782){pi+,pi-},K-},pi+}               spinfactors: 2  L: 1 [1-1]
+ 8 D0{K(1)(1270)-[GSpline.EFF]{rho(1450)0{pi+,pi-},K-},pi+}               spinfactors: 2  L: 1 [1-1]
+ 9 D0{K(1)(1270)-[GSpline.EFF]{rho(770)0{pi+,pi-},K-},pi+}                spinfactors: 2  L: 1 [1-1]
+10 D0{K(1)(1400)-{K*(892)~0{K-,pi+},pi-},pi+}                             spinfactors: 2  L: 1 [1-1]
+11 D0{K(1460)-[GSpline.EFF]{K*(892)~0{K-,pi+},pi-},pi+}                   spinfactors: 1  L: 0 [0-0]
+12 D0{K(1460)-[GSpline.EFF]{PiPi3[kMatrix.pole.0]{pi+,pi-},K-},pi+}       spinfactors: 1  L: 0 [0-0]
+13 D0{K(1460)-[GSpline.EFF]{PiPi3[kMatrix.pole.1]{pi+,pi-},K-},pi+}       spinfactors: 1  L: 0 [0-0]
+14 D0{K(1460)-[GSpline.EFF]{PiPi3[kMatrix.prod.1]{pi+,pi-},K-},pi+}       spinfactors: 1  L: 0 [0-0]
+15 D0{K(2)*(1430)-{K*(892)~0{K-,pi+},pi-},pi+}                            spinfactors: 2  L: 2 [2-2]
+16 D0{K*(892)~0{K-,pi+},PiPi1[kMatrix.pole.1]{pi+,pi-}}                   spinfactors: 2  L: 1 [1-1]
+17 D0{K*(892)~0{K-,pi+},PiPi1[kMatrix.prod.0]{pi+,pi-}}                   spinfactors: 2  L: 1 [1-1]
+18 D0{K*(892)~0{K-,pi+},rho(770)0{pi+,pi-}}                               spinfactors: 1  L: 0 [0-2]
+19 D0{KPi00[FOCUS.I32]{K-,pi+},PiPi0[kMatrix.pole.1]{pi+,pi-}}            spinfactors: 1  L: 0 [0-0]
+20 D0{KPi00[FOCUS.I32]{K-,pi+},PiPi0[kMatrix.prod.0]{pi+,pi-}}            spinfactors: 1  L: 0 [0-0]
+21 D0{KPi00[FOCUS.KEta]{K-,pi+},PiPi0[kMatrix.pole.1]{pi+,pi-}}           spinfactors: 1  L: 0 [0-0]
+22 D0{KPi00[FOCUS.KEta]{K-,pi+},PiPi0[kMatrix.prod.0]{pi+,pi-}}           spinfactors: 1  L: 0 [0-0]
+23 D0{KPi00[FOCUS.Kpi]{K-,pi+},PiPi0[kMatrix.pole.1]{pi+,pi-}}            spinfactors: 1  L: 0 [0-0]
+24 D0{KPi00[FOCUS.Kpi]{K-,pi+},PiPi0[kMatrix.prod.0]{pi+,pi-}}            spinfactors: 1  L: 0 [0-0]
+25 D0{a(1)(1260)+[D;GSpline.EFF]{rho(770)0{pi+,pi-},pi+},K-}              spinfactors: 2  L: 1 [1-1]
+26 D0{a(1)(1260)+[GSpline.EFF]{PiPi2[kMatrix.pole.0]{pi+,pi-},pi+},K-}    spinfactors: 2  L: 1 [1-1]
+27 D0{a(1)(1260)+[GSpline.EFF]{PiPi2[kMatrix.pole.1]{pi+,pi-},pi+},K-}    spinfactors: 2  L: 1 [1-1]
+28 D0{a(1)(1260)+[GSpline.EFF]{PiPi2[kMatrix.prod.0]{pi+,pi-},pi+},K-}    spinfactors: 2  L: 1 [1-1]
+29 D0{a(1)(1260)+[GSpline.EFF]{rho(770)0{pi+,pi-},pi+},K-}                spinfactors: 2  L: 1 [1-1]
+30 D0{rho(1450)0{pi+,pi-},K*(892)~0{K-,pi+}}                              spinfactors: 1  L: 0 [0-2]
+31 D0{rho(770)0{pi+,pi-},KPi10[FOCUS.I32]{K-,pi+}}                        spinfactors: 2  L: 1 [1-1]
+32 D0{rho(770)0{pi+,pi-},KPi10[FOCUS.Kpi]{K-,pi+}}                        spinfactors: 2  L: 1 [1-1]
 
 
 All discovered spin configurations:
@@ -141,8 +141,8 @@ ONE
 
     Variable PiPi1_M         { "PiPi1_M"            , 9990       };
     Variable PiPi1_W         { "PiPi1_W"            , 9.9e+09    };
-    Variable Kst_892_0_bar_M { "Kst_892_0_bar_M"    , 895.55     };
-    Variable Kst_892_0_bar_W { "Kst_892_0_bar_W"    , 47.3       };
+    Variable Kst_892_0_bar_M { "Kst_892_0_bar_M"    , 895.56     };
+    Variable Kst_892_0_bar_W { "Kst_892_0_bar_W"    , 47.1       };
     Variable KPi1_0_M        { "KPi1_0_M"           , 9990       };
     Variable KPi1_0_W        { "KPi1_0_W"           , 9.9e+09    };
     Variable rho_1450_0_M    { "rho_1450_0_M"       , 1465       };
@@ -159,7 +159,7 @@ ONE
     Variable K_1460_minus_W  { "K_1460_minus_W"     , 335.6      };
     Variable PiPi3_M         { "PiPi3_M"            , 9990       };
     Variable PiPi3_W         { "PiPi3_W"            , 9.9e+09    };
-    Variable K_1_1270_minus_M { "K_1_1270_minus_M"   , 1253       };
+    Variable K_1_1270_minus_M { "K_1_1270_minus_M"   , 1256       };
     Variable K_1_1270_minus_W { "K_1_1270_minus_W"   , 90         };
     Variable rho_770_0_M     { "rho_770_0_M"        , 775.26     };
     Variable rho_770_0_W     { "rho_770_0_W"        , 147.4      };
@@ -535,10 +535,10 @@ ONE
     }));
 
     line_factor_list.push_back(std::vector<Lineshape*>{
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_12, FF::BL2),
-        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1.0, M_34, FF::BL2),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_13, FF::BL2),
-        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1.0, M_24, FF::BL2)
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_12, FF::BL2),
+        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1, M_34, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_13, FF::BL2),
+        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1, M_24, FF::BL2)
     });
 
     amplitudes_list.push_back(new Amplitude{
@@ -563,10 +563,10 @@ ONE
     }));
 
     line_factor_list.push_back(std::vector<Lineshape*>{
-        new Lineshapes::RBW("rho(1450)0", rho_1450_0_M, rho_1450_0_W, 1.0, M_24, FF::BL2),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_13, FF::BL2),
-        new Lineshapes::RBW("rho(1450)0", rho_1450_0_M, rho_1450_0_W, 1.0, M_34, FF::BL2),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_12, FF::BL2)
+        new Lineshapes::RBW("rho(1450)0", rho_1450_0_M, rho_1450_0_W, 1, M_24, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_13, FF::BL2),
+        new Lineshapes::RBW("rho(1450)0", rho_1450_0_M, rho_1450_0_W, 1, M_34, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_12, FF::BL2)
     });
 
     amplitudes_list.push_back(new Amplitude{
@@ -591,10 +591,10 @@ ONE
     }));
 
     line_factor_list.push_back(std::vector<Lineshape*>{
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_12, FF::BL2),
-        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1.0, M_34, FF::BL2),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_13, FF::BL2),
-        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1.0, M_24, FF::BL2)
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_12, FF::BL2),
+        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1, M_34, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_13, FF::BL2),
+        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1, M_24, FF::BL2)
     });
 
     amplitudes_list.push_back(new Amplitude{
@@ -619,10 +619,10 @@ ONE
     }));
 
     line_factor_list.push_back(std::vector<Lineshape*>{
-        new Lineshapes::RBW("rho(1450)0", rho_1450_0_M, rho_1450_0_W, 1.0, M_24, FF::BL2),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_13, FF::BL2),
-        new Lineshapes::RBW("rho(1450)0", rho_1450_0_M, rho_1450_0_W, 1.0, M_34, FF::BL2),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_12, FF::BL2)
+        new Lineshapes::RBW("rho(1450)0", rho_1450_0_M, rho_1450_0_W, 1, M_24, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_13, FF::BL2),
+        new Lineshapes::RBW("rho(1450)0", rho_1450_0_M, rho_1450_0_W, 1, M_34, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_12, FF::BL2)
     });
 
     amplitudes_list.push_back(new Amplitude{
@@ -649,10 +649,10 @@ ONE
     line_factor_list.push_back(std::vector<Lineshape*>{
         new Lineshapes::GSpline("K(1)(1270)bar-", K_1_1270_minus_M, K_1_1270_minus_W, 2, M_12_4, FF::BL2,
             1.5, K_1_1270bar_minus_SplineArr, Lineshapes::spline_t(0.6,3.0,40)),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_12, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_12, FF::BL2),
         new Lineshapes::GSpline("K(1)(1270)bar-", K_1_1270_minus_M, K_1_1270_minus_W, 2, M_13_4, FF::BL2,
             1.5, K_1_1270bar_minus_SplineArr, Lineshapes::spline_t(0.6,3.0,40)),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_13, FF::BL2)
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_13, FF::BL2)
     });
 
     amplitudes_list.push_back(new Amplitude{
@@ -679,10 +679,10 @@ ONE
     line_factor_list.push_back(std::vector<Lineshape*>{
         new Lineshapes::GSpline("K(1)(1270)bar-", K_1_1270_minus_M, K_1_1270_minus_W, 0, M_12_4, FF::BL2,
             1.5, K_1_1270bar_minus_SplineArr, Lineshapes::spline_t(0.6,3.0,40)),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_12, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_12, FF::BL2),
         new Lineshapes::GSpline("K(1)(1270)bar-", K_1_1270_minus_M, K_1_1270_minus_W, 0, M_13_4, FF::BL2,
             1.5, K_1_1270bar_minus_SplineArr, Lineshapes::spline_t(0.6,3.0,40)),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_13, FF::BL2)
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_13, FF::BL2)
     });
 
     amplitudes_list.push_back(new Amplitude{
@@ -707,10 +707,10 @@ ONE
     }));
 
     line_factor_list.push_back(std::vector<Lineshape*>{
-        new Lineshapes::GSpline("K(1)(1270)bar-", K_1_1270_minus_M, K_1_1270_minus_W, 1.0, M_12_4, FF::BL2,
+        new Lineshapes::GSpline("K(1)(1270)bar-", K_1_1270_minus_M, K_1_1270_minus_W, 1, M_12_4, FF::BL2,
             1.5, K_1_1270bar_minus_SplineArr, Lineshapes::spline_t(0.6,3.0,40)),
         new Lineshapes::FOCUS("KPi20", Lineshapes::FOCUS::Mod::Kpi, KPi2_0_M, KPi2_0_W, 0, M_12, FF::BL2, 1.5),
-        new Lineshapes::GSpline("K(1)(1270)bar-", K_1_1270_minus_M, K_1_1270_minus_W, 1.0, M_13_4, FF::BL2,
+        new Lineshapes::GSpline("K(1)(1270)bar-", K_1_1270_minus_M, K_1_1270_minus_W, 1, M_13_4, FF::BL2,
             1.5, K_1_1270bar_minus_SplineArr, Lineshapes::spline_t(0.6,3.0,40)),
         new Lineshapes::FOCUS("KPi20", Lineshapes::FOCUS::Mod::Kpi, KPi2_0_M, KPi2_0_W, 0, M_13, FF::BL2, 1.5)
     });
@@ -739,10 +739,10 @@ ONE
     line_factor_list.push_back(std::vector<Lineshape*>{
         new Lineshapes::GSpline("K(1)(1270)bar-", K_1_1270_minus_M, K_1_1270_minus_W, 0, M_24_1, FF::BL2,
             1.5, K_1_1270bar_minus_SplineArr, Lineshapes::spline_t(0.6,3.0,40)),
-        new Lineshapes::RBW("omega(782)0", omega_782_M, omega_782_W, 1.0, M_24, FF::BL2),
+        new Lineshapes::RBW("omega(782)0", omega_782_M, omega_782_W, 1, M_24, FF::BL2),
         new Lineshapes::GSpline("K(1)(1270)bar-", K_1_1270_minus_M, K_1_1270_minus_W, 0, M_34_1, FF::BL2,
             1.5, K_1_1270bar_minus_SplineArr, Lineshapes::spline_t(0.6,3.0,40)),
-        new Lineshapes::RBW("omega(782)0", omega_782_M, omega_782_W, 1.0, M_34, FF::BL2)
+        new Lineshapes::RBW("omega(782)0", omega_782_M, omega_782_W, 1, M_34, FF::BL2)
     });
 
     amplitudes_list.push_back(new Amplitude{
@@ -769,10 +769,10 @@ ONE
     line_factor_list.push_back(std::vector<Lineshape*>{
         new Lineshapes::GSpline("K(1)(1270)bar-", K_1_1270_minus_M, K_1_1270_minus_W, 0, M_24_1, FF::BL2,
             1.5, K_1_1270bar_minus_SplineArr, Lineshapes::spline_t(0.6,3.0,40)),
-        new Lineshapes::RBW("rho(1450)0", rho_1450_0_M, rho_1450_0_W, 1.0, M_24, FF::BL2),
+        new Lineshapes::RBW("rho(1450)0", rho_1450_0_M, rho_1450_0_W, 1, M_24, FF::BL2),
         new Lineshapes::GSpline("K(1)(1270)bar-", K_1_1270_minus_M, K_1_1270_minus_W, 0, M_34_1, FF::BL2,
             1.5, K_1_1270bar_minus_SplineArr, Lineshapes::spline_t(0.6,3.0,40)),
-        new Lineshapes::RBW("rho(1450)0", rho_1450_0_M, rho_1450_0_W, 1.0, M_34, FF::BL2)
+        new Lineshapes::RBW("rho(1450)0", rho_1450_0_M, rho_1450_0_W, 1, M_34, FF::BL2)
     });
 
     amplitudes_list.push_back(new Amplitude{
@@ -799,10 +799,10 @@ ONE
     line_factor_list.push_back(std::vector<Lineshape*>{
         new Lineshapes::GSpline("K(1)(1270)bar-", K_1_1270_minus_M, K_1_1270_minus_W, 0, M_24_1, FF::BL2,
             1.5, K_1_1270bar_minus_SplineArr, Lineshapes::spline_t(0.6,3.0,40)),
-        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1.0, M_24, FF::BL2),
+        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1, M_24, FF::BL2),
         new Lineshapes::GSpline("K(1)(1270)bar-", K_1_1270_minus_M, K_1_1270_minus_W, 0, M_34_1, FF::BL2,
             1.5, K_1_1270bar_minus_SplineArr, Lineshapes::spline_t(0.6,3.0,40)),
-        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1.0, M_34, FF::BL2)
+        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1, M_34, FF::BL2)
     });
 
     amplitudes_list.push_back(new Amplitude{
@@ -828,9 +828,9 @@ ONE
 
     line_factor_list.push_back(std::vector<Lineshape*>{
         new Lineshapes::RBW("K(1)(1400)bar-", K_1_1400_minus_M, K_1_1400_minus_W, 0, M_12_4, FF::BL2),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_12, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_12, FF::BL2),
         new Lineshapes::RBW("K(1)(1400)bar-", K_1_1400_minus_M, K_1_1400_minus_W, 0, M_13_4, FF::BL2),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_13, FF::BL2)
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_13, FF::BL2)
     });
 
     amplitudes_list.push_back(new Amplitude{
@@ -853,12 +853,12 @@ ONE
     }));
 
     line_factor_list.push_back(std::vector<Lineshape*>{
-        new Lineshapes::GSpline("K(1460)bar-", K_1460_minus_M, K_1460_minus_W, 1.0, M_12_4, FF::BL2,
+        new Lineshapes::GSpline("K(1460)bar-", K_1460_minus_M, K_1460_minus_W, 1, M_12_4, FF::BL2,
             1.5, K_1460bar_minus_SplineArr, Lineshapes::spline_t(0.6,3.0,40)),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_12, FF::BL2),
-        new Lineshapes::GSpline("K(1460)bar-", K_1460_minus_M, K_1460_minus_W, 1.0, M_13_4, FF::BL2,
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_12, FF::BL2),
+        new Lineshapes::GSpline("K(1460)bar-", K_1460_minus_M, K_1460_minus_W, 1, M_13_4, FF::BL2,
             1.5, K_1460bar_minus_SplineArr, Lineshapes::spline_t(0.6,3.0,40)),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_13, FF::BL2)
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_13, FF::BL2)
     });
 
     amplitudes_list.push_back(new Amplitude{
@@ -985,10 +985,10 @@ ONE
     }));
 
     line_factor_list.push_back(std::vector<Lineshape*>{
-        new Lineshapes::RBW("K(2)*(1430)bar-", K_2st_1430_minus_M, K_2st_1430_minus_W, 1.0, M_12_4, FF::BL2),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_12, FF::BL2),
-        new Lineshapes::RBW("K(2)*(1430)bar-", K_2st_1430_minus_M, K_2st_1430_minus_W, 1.0, M_13_4, FF::BL2),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_13, FF::BL2)
+        new Lineshapes::RBW("K(2)*(1430)bar-", K_2st_1430_minus_M, K_2st_1430_minus_W, 1, M_12_4, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_12, FF::BL2),
+        new Lineshapes::RBW("K(2)*(1430)bar-", K_2st_1430_minus_M, K_2st_1430_minus_W, 1, M_13_4, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_13, FF::BL2)
     });
 
     amplitudes_list.push_back(new Amplitude{
@@ -1013,12 +1013,12 @@ ONE
     }));
 
     line_factor_list.push_back(std::vector<Lineshape*>{
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_12, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_12, FF::BL2),
         new Lineshapes::kMatrix("PiPi10", 1, true,
             sA_0, sA, s0_prod, s0_scatt,
             f_scatt, IS_poles,
             PiPi1_M, PiPi1_W, 0, M_34, FF::BL2, 1.5),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_13, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_13, FF::BL2),
         new Lineshapes::kMatrix("PiPi10", 1, true,
             sA_0, sA, s0_prod, s0_scatt,
             f_scatt, IS_poles,
@@ -1047,12 +1047,12 @@ ONE
     }));
 
     line_factor_list.push_back(std::vector<Lineshape*>{
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_12, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_12, FF::BL2),
         new Lineshapes::kMatrix("PiPi10", 0, false,
             sA_0, sA, s0_prod, s0_scatt,
             f_scatt, IS_poles,
             PiPi1_M, PiPi1_W, 0, M_34, FF::BL2, 1.5),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_13, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_13, FF::BL2),
         new Lineshapes::kMatrix("PiPi10", 0, false,
             sA_0, sA, s0_prod, s0_scatt,
             f_scatt, IS_poles,
@@ -1079,10 +1079,10 @@ ONE
     }));
 
     line_factor_list.push_back(std::vector<Lineshape*>{
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_12, FF::BL2),
-        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1.0, M_34, FF::BL2),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_13, FF::BL2),
-        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1.0, M_24, FF::BL2)
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_12, FF::BL2),
+        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1, M_34, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_13, FF::BL2),
+        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1, M_24, FF::BL2)
     });
 
     amplitudes_list.push_back(new Amplitude{
@@ -1301,10 +1301,10 @@ ONE
     line_factor_list.push_back(std::vector<Lineshape*>{
         new Lineshapes::GSpline("a(1)(1260)+", a_1_1260_plus_M, a_1_1260_plus_W, 2, M_24_3, FF::BL2,
             1.5, a_1_1260_plus_SplineArr, Lineshapes::spline_t(0.18412,1.9,40)),
-        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1.0, M_24, FF::BL2),
+        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1, M_24, FF::BL2),
         new Lineshapes::GSpline("a(1)(1260)+", a_1_1260_plus_M, a_1_1260_plus_W, 2, M_34_2, FF::BL2,
             1.5, a_1_1260_plus_SplineArr, Lineshapes::spline_t(0.18412,1.9,40)),
-        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1.0, M_34, FF::BL2)
+        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1, M_34, FF::BL2)
     });
 
     amplitudes_list.push_back(new Amplitude{
@@ -1329,13 +1329,13 @@ ONE
     }));
 
     line_factor_list.push_back(std::vector<Lineshape*>{
-        new Lineshapes::GSpline("a(1)(1260)+", a_1_1260_plus_M, a_1_1260_plus_W, 1.0, M_24_3, FF::BL2,
+        new Lineshapes::GSpline("a(1)(1260)+", a_1_1260_plus_M, a_1_1260_plus_W, 1, M_24_3, FF::BL2,
             1.5, a_1_1260_plus_SplineArr, Lineshapes::spline_t(0.18412,1.9,40)),
         new Lineshapes::kMatrix("PiPi20", 0, true,
             sA_0, sA, s0_prod, s0_scatt,
             f_scatt, IS_poles,
             PiPi2_M, PiPi2_W, 0, M_24, FF::BL2, 1.5),
-        new Lineshapes::GSpline("a(1)(1260)+", a_1_1260_plus_M, a_1_1260_plus_W, 1.0, M_34_2, FF::BL2,
+        new Lineshapes::GSpline("a(1)(1260)+", a_1_1260_plus_M, a_1_1260_plus_W, 1, M_34_2, FF::BL2,
             1.5, a_1_1260_plus_SplineArr, Lineshapes::spline_t(0.18412,1.9,40)),
         new Lineshapes::kMatrix("PiPi20", 0, true,
             sA_0, sA, s0_prod, s0_scatt,
@@ -1365,13 +1365,13 @@ ONE
     }));
 
     line_factor_list.push_back(std::vector<Lineshape*>{
-        new Lineshapes::GSpline("a(1)(1260)+", a_1_1260_plus_M, a_1_1260_plus_W, 1.0, M_24_3, FF::BL2,
+        new Lineshapes::GSpline("a(1)(1260)+", a_1_1260_plus_M, a_1_1260_plus_W, 1, M_24_3, FF::BL2,
             1.5, a_1_1260_plus_SplineArr, Lineshapes::spline_t(0.18412,1.9,40)),
         new Lineshapes::kMatrix("PiPi20", 1, true,
             sA_0, sA, s0_prod, s0_scatt,
             f_scatt, IS_poles,
             PiPi2_M, PiPi2_W, 0, M_24, FF::BL2, 1.5),
-        new Lineshapes::GSpline("a(1)(1260)+", a_1_1260_plus_M, a_1_1260_plus_W, 1.0, M_34_2, FF::BL2,
+        new Lineshapes::GSpline("a(1)(1260)+", a_1_1260_plus_M, a_1_1260_plus_W, 1, M_34_2, FF::BL2,
             1.5, a_1_1260_plus_SplineArr, Lineshapes::spline_t(0.18412,1.9,40)),
         new Lineshapes::kMatrix("PiPi20", 1, true,
             sA_0, sA, s0_prod, s0_scatt,
@@ -1401,13 +1401,13 @@ ONE
     }));
 
     line_factor_list.push_back(std::vector<Lineshape*>{
-        new Lineshapes::GSpline("a(1)(1260)+", a_1_1260_plus_M, a_1_1260_plus_W, 1.0, M_24_3, FF::BL2,
+        new Lineshapes::GSpline("a(1)(1260)+", a_1_1260_plus_M, a_1_1260_plus_W, 1, M_24_3, FF::BL2,
             1.5, a_1_1260_plus_SplineArr, Lineshapes::spline_t(0.18412,1.9,40)),
         new Lineshapes::kMatrix("PiPi20", 0, false,
             sA_0, sA, s0_prod, s0_scatt,
             f_scatt, IS_poles,
             PiPi2_M, PiPi2_W, 0, M_24, FF::BL2, 1.5),
-        new Lineshapes::GSpline("a(1)(1260)+", a_1_1260_plus_M, a_1_1260_plus_W, 1.0, M_34_2, FF::BL2,
+        new Lineshapes::GSpline("a(1)(1260)+", a_1_1260_plus_M, a_1_1260_plus_W, 1, M_34_2, FF::BL2,
             1.5, a_1_1260_plus_SplineArr, Lineshapes::spline_t(0.18412,1.9,40)),
         new Lineshapes::kMatrix("PiPi20", 0, false,
             sA_0, sA, s0_prod, s0_scatt,
@@ -1439,10 +1439,10 @@ ONE
     line_factor_list.push_back(std::vector<Lineshape*>{
         new Lineshapes::GSpline("a(1)(1260)+", a_1_1260_plus_M, a_1_1260_plus_W, 0, M_24_3, FF::BL2,
             1.5, a_1_1260_plus_SplineArr, Lineshapes::spline_t(0.18412,1.9,40)),
-        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1.0, M_24, FF::BL2),
+        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1, M_24, FF::BL2),
         new Lineshapes::GSpline("a(1)(1260)+", a_1_1260_plus_M, a_1_1260_plus_W, 0, M_34_2, FF::BL2,
             1.5, a_1_1260_plus_SplineArr, Lineshapes::spline_t(0.18412,1.9,40)),
-        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1.0, M_34, FF::BL2)
+        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1, M_34, FF::BL2)
     });
 
     amplitudes_list.push_back(new Amplitude{
@@ -1465,10 +1465,10 @@ ONE
     }));
 
     line_factor_list.push_back(std::vector<Lineshape*>{
-        new Lineshapes::RBW("rho(1450)0", rho_1450_0_M, rho_1450_0_W, 1.0, M_24, FF::BL2),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_13, FF::BL2),
-        new Lineshapes::RBW("rho(1450)0", rho_1450_0_M, rho_1450_0_W, 1.0, M_34, FF::BL2),
-        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1.0, M_12, FF::BL2)
+        new Lineshapes::RBW("rho(1450)0", rho_1450_0_M, rho_1450_0_W, 1, M_24, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_13, FF::BL2),
+        new Lineshapes::RBW("rho(1450)0", rho_1450_0_M, rho_1450_0_W, 1, M_34, FF::BL2),
+        new Lineshapes::RBW("K*(892)bar0", Kst_892_0_bar_M, Kst_892_0_bar_W, 1, M_12, FF::BL2)
     });
 
     amplitudes_list.push_back(new Amplitude{
@@ -1493,9 +1493,9 @@ ONE
     }));
 
     line_factor_list.push_back(std::vector<Lineshape*>{
-        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1.0, M_24, FF::BL2),
+        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1, M_24, FF::BL2),
         new Lineshapes::FOCUS("KPi10", Lineshapes::FOCUS::Mod::I32, KPi1_0_M, KPi1_0_W, 0, M_13, FF::BL2, 1.5),
-        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1.0, M_34, FF::BL2),
+        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1, M_34, FF::BL2),
         new Lineshapes::FOCUS("KPi10", Lineshapes::FOCUS::Mod::I32, KPi1_0_M, KPi1_0_W, 0, M_12, FF::BL2, 1.5)
     });
 
@@ -1521,9 +1521,9 @@ ONE
     }));
 
     line_factor_list.push_back(std::vector<Lineshape*>{
-        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1.0, M_24, FF::BL2),
+        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1, M_24, FF::BL2),
         new Lineshapes::FOCUS("KPi10", Lineshapes::FOCUS::Mod::Kpi, KPi1_0_M, KPi1_0_W, 0, M_13, FF::BL2, 1.5),
-        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1.0, M_34, FF::BL2),
+        new Lineshapes::RBW("rho(770)0", rho_770_0_M, rho_770_0_W, 1, M_34, FF::BL2),
         new Lineshapes::FOCUS("KPi10", Lineshapes::FOCUS::Mod::Kpi, KPi1_0_M, KPi1_0_W, 0, M_12, FF::BL2, 1.5)
     });
 


### PR DESCRIPTION
* Parsing of decay files (aka .dec files):
  - Performance improvements in `DecFileParser`, with caching and lazily-built indexing where possible.
  - A couple of fixes related to the decay file parser.
  - Various improvements to the code, for more robustness.
  - Typing modernisations.
  - Code simplifications to various helper functions.
  - Updated the `known_decay_models` comment in `dec/enums.py` to reflect that
    the list is injected via `edit_terminals` rather than a static grammar terminal.
* Universal representation of decay chains:
  - Added `DaughtersDict.__sub__`, returning a `DaughtersDict` (mirrors `__add__`).
  - Fixed `DecayChain.from_dict` so it can read back its own `to_dict` output when the same particle
    appears more than once with an identical sub-decay (e.g. `eta -> pi0 pi0` with `pi0 -> gamma gamma`);
    genuinely conflicting redefinitions still raise.
  - `DecayChainViewer` now uses a per-instance node counter,
    so rendering the same chain twice yields identical, reproducible DOT output.
  - `DecayChainViewer` now HTML-escapes particle names in its fallback label path,
     producing valid DOT for names containing `&`, `<`, `>`.
  - Modernisations in `decay/` and `utils/`.
  - Other minor fixes.
* Modeling submodule (`modeling/`):
  - Migrated `ModelDecay` and `AmplitudeChain` to modern `@attrs.define`/`attrs.field`.
  - Several AmpGen to GooFit conversion fixes (fix/free flags, polar-to-cartesian error propagation, spin factor mappings, state leakage, output formatting, and more).
  - Various other fixes and minor improvements.
* Utilities submodule:
  - Fixed a bug in `split()` where a trailing comma was not handled correctly
    (e.g. `split("a,")` returned `["a,"]` instead of `["a", ""]`).
  - Fixed `filter_lines()` to collect matched lines and residuals in a single pass
    instead of running the regex twice per line.
* Documentation:
  - Expanded the README to cover recently added, Flavour-Physics-oriented features:
    inspecting decay modes (`list_decay_modes`, `print_decay_modes`, `expand_decay_modes`),
    pruning decay chains via `build_decay_chains(..., minimum_effective_bf=...)`
    and annotating them with `DecayChainViewer(..., show_effective_bf=True)`,
    and text-based decay-chain tools (`to_string`, `print_as_tree`, `flatten`,
    `DaughtersDict` arithmetic and charge conjugation).
* Dependencies:
  - Moved `numpy`, `pandas` and `plumbum` into an optional `decaylanguage[modeling]` extra; they are only needed by the `modeling` subpackage and the command-line interface. Core `.dec` parsing and decay-chain functionality no longer pull them in.
* Miscellaneous - typing:
  - Reviewed and reduced `# type: ignore` comments across submodules.
* CI and tests:
  - Several improvements, enhancements and clean_ups.
  - Removed dead `filterwarnings` ignore for PyArrow/pandas deprecation (pandas >=2.2.2 no longer emits it).
  - Trimmed mypy pre-commit hook's `additional_dependencies` to only what the covered code actually imports (`particle`, `hepunits`).
  - Raised minimum dependency floors to oldest versions with cp310 wheels: `numpy>=1.21.6`, `pandas>=2.0`.