### PR TITLE
fix: distinguish duplicate CDecay statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Next
+
+* Decay-file validation:
+  - Renamed diagnostic `DLW003` to `decay-cdecay-conflict` to describe a
+    particle defined by both `Decay` and `CDecay`.
+  - Added `DLW006` (`duplicate-cdecay`) for repeated `CDecay` statements;
+    later occurrences are now ignored.
+
 ## Version 1.1.0 (2026-07-27)
 
 * Parsing of decay files (aka .dec files):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 * Decay-file validation:
   - Renamed diagnostic `DLW003` to `decay-cdecay-conflict` to describe a
     particle defined by both `Decay` and `CDecay`.
-  - Added `DLW006` (`duplicate-cdecay`) for repeated `CDecay` statements;
+  - Added `DLW002` (`duplicate-cdecay`) for repeated `CDecay` statements;
     later occurrences are now ignored.
+  - Renumbered `missing-copydecay-source` to `DLW006`.
 
 ## Version 1.1.0 (2026-07-27)
 

--- a/README.md
+++ b/README.md
@@ -224,9 +224,10 @@ Available diagnostics:
 | `DLP001` | `parse-error` | The file could not be read or parsed by `DecFileParser`. |
 | `DLW001` | `duplicate-decay` | A particle has multiple `Decay` blocks; only the first is retained. |
 | `DLW002` | `missing-copydecay-source` | A `CopyDecay` statement references a missing `Decay` source. |
-| `DLW003` | `duplicate-cdecay` | A particle is defined with both `Decay` and `CDecay`; `CDecay` is ignored. |
+| `DLW003` | `decay-cdecay-conflict` | A particle is defined with both `Decay` and `CDecay`; `CDecay` is ignored. |
 | `DLW004` | `missing-cdecay-source` | A `CDecay` statement has no corresponding `Decay` source. |
 | `DLW005` | `self-conjugate-cdecay` | A `CDecay` statement targets a self-conjugate particle. |
+| `DLW006` | `duplicate-cdecay` | A particle has multiple `CDecay` statements; only the first is retained. |
 | `DLW999` | `parser-warning` | An otherwise unclassified warning was emitted by `DecFileParser`. |
 
 When the hook finds a problem, pre-commit prints the validator output. A parser

--- a/README.md
+++ b/README.md
@@ -223,11 +223,11 @@ Available diagnostics:
 | --- | --- | --- |
 | `DLP001` | `parse-error` | The file could not be read or parsed by `DecFileParser`. |
 | `DLW001` | `duplicate-decay` | A particle has multiple `Decay` blocks; only the first is retained. |
-| `DLW002` | `missing-copydecay-source` | A `CopyDecay` statement references a missing `Decay` source. |
+| `DLW002` | `duplicate-cdecay` | A particle has multiple `CDecay` statements; only the first is retained. |
 | `DLW003` | `decay-cdecay-conflict` | A particle is defined with both `Decay` and `CDecay`; `CDecay` is ignored. |
 | `DLW004` | `missing-cdecay-source` | A `CDecay` statement has no corresponding `Decay` source. |
 | `DLW005` | `self-conjugate-cdecay` | A `CDecay` statement targets a self-conjugate particle. |
-| `DLW006` | `duplicate-cdecay` | A particle has multiple `CDecay` statements; only the first is retained. |
+| `DLW006` | `missing-copydecay-source` | A `CopyDecay` statement references a missing `Decay` source. |
 | `DLW999` | `parser-warning` | An otherwise unclassified warning was emitted by `DecFileParser`. |
 
 When the hook finds a problem, pre-commit prints the validator output. A parser

--- a/docs/examples/decfile_parsing.rst
+++ b/docs/examples/decfile_parsing.rst
@@ -91,8 +91,8 @@ available diagnostics, which are the following:
      - ``duplicate-decay``
      - A particle has multiple ``Decay`` blocks; only the first is retained.
    * - ``DLW002``
-     - ``missing-copydecay-source``
-     - A ``CopyDecay`` statement references a missing ``Decay`` source.
+     - ``duplicate-cdecay``
+     - A particle has multiple ``CDecay`` statements; only the first is retained.
    * - ``DLW003``
      - ``decay-cdecay-conflict``
      - A particle is defined with both ``Decay`` and ``CDecay``; ``CDecay`` is ignored.
@@ -103,8 +103,8 @@ available diagnostics, which are the following:
      - ``self-conjugate-cdecay``
      - A ``CDecay`` statement targets a self-conjugate particle.
    * - ``DLW006``
-     - ``duplicate-cdecay``
-     - A particle has multiple ``CDecay`` statements; only the first is retained.
+     - ``missing-copydecay-source``
+     - A ``CopyDecay`` statement references a missing ``Decay`` source.
    * - ``DLW999``
      - ``parser-warning``
      - An otherwise unclassified warning was emitted by ``DecFileParser``.

--- a/docs/examples/decfile_parsing.rst
+++ b/docs/examples/decfile_parsing.rst
@@ -94,7 +94,7 @@ available diagnostics, which are the following:
      - ``missing-copydecay-source``
      - A ``CopyDecay`` statement references a missing ``Decay`` source.
    * - ``DLW003``
-     - ``duplicate-cdecay``
+     - ``decay-cdecay-conflict``
      - A particle is defined with both ``Decay`` and ``CDecay``; ``CDecay`` is ignored.
    * - ``DLW004``
      - ``missing-cdecay-source``
@@ -102,6 +102,9 @@ available diagnostics, which are the following:
    * - ``DLW005``
      - ``self-conjugate-cdecay``
      - A ``CDecay`` statement targets a self-conjugate particle.
+   * - ``DLW006``
+     - ``duplicate-cdecay``
+     - A particle has multiple ``CDecay`` statements; only the first is retained.
    * - ``DLW999``
      - ``parser-warning``
      - An otherwise unclassified warning was emitted by ``DecFileParser``.
@@ -122,7 +125,7 @@ Parser warnings are reported more compactly:
 
    DecayLanguage: 2 diagnostic(s) in 1 file(s)
    tests/data/duplicate-decays.dec: DLW001 duplicate-decay: duplicate Decay block(s): Sigma(1775)0; later definitions ignored
-   tests/data/duplicate-decays.dec: DLW003 duplicate-cdecay: both Decay and CDecay defined: anti-Sigma(1775)0; CDecay ignored
+   tests/data/duplicate-decays.dec: DLW003 decay-cdecay-conflict: both Decay and CDecay defined: anti-Sigma(1775)0; CDecay ignored
    summary: DLW001=1, DLW003=1
 
 By default, at most 100 diagnostics are printed before the remaining diagnostics

--- a/docs/getting_started/quickstart.rst
+++ b/docs/getting_started/quickstart.rst
@@ -38,7 +38,7 @@ On failure, the validator prints output such as:
 
    DecayLanguage: 2 diagnostic(s) in 1 file(s)
    tests/data/duplicate-decays.dec: DLW001 duplicate-decay: duplicate Decay block(s): Sigma(1775)0; later definitions ignored
-   tests/data/duplicate-decays.dec: DLW003 duplicate-cdecay: both Decay and CDecay defined: anti-Sigma(1775)0; CDecay ignored
+   tests/data/duplicate-decays.dec: DLW003 decay-cdecay-conflict: both Decay and CDecay defined: anti-Sigma(1775)0; CDecay ignored
    summary: DLW001=1, DLW003=1
 
 Use ``decaylanguage-validate --list-diagnostics`` to list the available

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -759,7 +759,7 @@ Skipping creation of these copied decay trees.""".format("\n".join(misses))
         duplicate_cdecays = [name for name, count in counts.items() if count > 1]
         if duplicate_cdecays:
             msg = """The following particle(s) is(are) redefined in the input .dec file with 'CDecay': {}!
-All but the first occurrence will be discarded/removed ...""".format(
+All but the first occurrence(s) will be discarded/removed ...""".format(
                 ", ".join(duplicate_cdecays)
             )
             warnings.warn(msg, DuplicateCDecayWarning, stacklevel=2)
@@ -862,7 +862,7 @@ Skipping creation of charge-conjugate decay Tree."""
         # Issue a helpful warning if duplicates are found
         if duplicates:
             msg = """The following particle(s) is(are) redefined in the input .dec file with 'Decay': {}!
-All but the first occurrence will be discarded/removed ...""".format(
+All but the first occurrence(s) will be discarded/removed ...""".format(
                 ", ".join(duplicates)
             )
 

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -81,7 +81,7 @@ class DuplicateDecayWarning(DecFileWarning):
     code = "DLW001"
 
 
-class MissingCopyDecaySourceWarning(DecFileWarning):
+class DuplicateCDecayWarning(DecFileWarning):
     code = "DLW002"
 
 
@@ -97,7 +97,7 @@ class SelfConjugateCDecayWarning(DecFileWarning):
     code = "DLW005"
 
 
-class DuplicateCDecayWarning(DecFileWarning):
+class MissingCopyDecaySourceWarning(DecFileWarning):
     code = "DLW006"
 
 

--- a/src/decaylanguage/dec/dec.py
+++ b/src/decaylanguage/dec/dec.py
@@ -85,7 +85,7 @@ class MissingCopyDecaySourceWarning(DecFileWarning):
     code = "DLW002"
 
 
-class DuplicateCDecayWarning(DecFileWarning):
+class DecayAndCDecayWarning(DecFileWarning):
     code = "DLW003"
 
 
@@ -95,6 +95,10 @@ class MissingCDecaySourceWarning(DecFileWarning):
 
 class SelfConjugateCDecayWarning(DecFileWarning):
     code = "DLW005"
+
+
+class DuplicateCDecayWarning(DecFileWarning):
+    code = "DLW006"
 
 
 @cache
@@ -749,6 +753,18 @@ Skipping creation of these copied decay trees.""".format("\n".join(misses))
 
         assert self._parsed_decays is not None
 
+        # As for duplicate Decay blocks, retain only the first CDecay
+        # statement for each particle.
+        counts = Counter(mother_names_ccdecays)
+        duplicate_cdecays = [name for name, count in counts.items() if count > 1]
+        if duplicate_cdecays:
+            msg = """The following particle(s) is(are) redefined in the input .dec file with 'CDecay': {}!
+All but the first occurrence will be discarded/removed ...""".format(
+                ", ".join(duplicate_cdecays)
+            )
+            warnings.warn(msg, DuplicateCDecayWarning, stacklevel=2)
+            mother_names_ccdecays = list(dict.fromkeys(mother_names_ccdecays))
+
         # Cross-check - make sure charge conjugate decays are not defined
         # with both 'Decay' and 'CDecay' statements!
         mother_names_decays = [
@@ -760,7 +776,7 @@ Skipping creation of these copied decay trees.""".format("\n".join(misses))
             str_duplicates = ", ".join(d for d in duplicates)
             msg = f"""The following particles are defined in the input .dec file with both 'Decay' and 'CDecay': {str_duplicates}!
 The 'CDecay' definition(s) will be ignored ..."""
-            warnings.warn(msg, DuplicateCDecayWarning, stacklevel=2)
+            warnings.warn(msg, DecayAndCDecayWarning, stacklevel=2)
 
         # If that's the case, proceed using the decay definitions specified
         # via the 'Decay' statement, hence discard/remove the definition

--- a/src/decaylanguage/dec/validate.py
+++ b/src/decaylanguage/dec/validate.py
@@ -64,8 +64,8 @@ DLW001 = DiagnosticRule(
 )
 DLW002 = DiagnosticRule(
     "DLW002",
-    "missing-copydecay-source",
-    "A CopyDecay statement references a missing Decay source.",
+    "duplicate-cdecay",
+    "A particle has multiple CDecay statements; only the first is retained.",
 )
 DLW003 = DiagnosticRule(
     "DLW003",
@@ -84,8 +84,8 @@ DLW005 = DiagnosticRule(
 )
 DLW006 = DiagnosticRule(
     "DLW006",
-    "duplicate-cdecay",
-    "A particle has multiple CDecay statements; only the first is retained.",
+    "missing-copydecay-source",
+    "A CopyDecay statement references a missing Decay source.",
 )
 DLW999 = DiagnosticRule(
     "DLW999",
@@ -248,9 +248,11 @@ def _compact_warning_message(rule: DiagnosticRule, message: str) -> str:
         if particles is not None:
             return f"duplicate Decay block(s): {particles}; later definitions ignored"
     if rule is DLW002:
-        particles = _search_message(message, r"not found: (?P<particles>.*?)\.")
+        particles = _search_message(message, r"with 'CDecay': (?P<particles>.*?)!")
         if particles is not None:
-            return f"missing Decay source for CopyDecay: {particles}"
+            return (
+                f"duplicate CDecay statement(s): {particles}; later statements ignored"
+            )
     if rule is DLW003:
         particles = _search_message(message, r"'CDecay': (?P<particles>.*?)!")
         if particles is not None:
@@ -267,11 +269,9 @@ def _compact_warning_message(rule: DiagnosticRule, message: str) -> str:
         if particle is not None:
             return f"CDecay targets self-conjugate particle: {particle}"
     if rule is DLW006:
-        particles = _search_message(message, r"with 'CDecay': (?P<particles>.*?)!")
+        particles = _search_message(message, r"not found: (?P<particles>.*?)\.")
         if particles is not None:
-            return (
-                f"duplicate CDecay statement(s): {particles}; later statements ignored"
-            )
+            return f"missing Decay source for CopyDecay: {particles}"
     return message
 
 

--- a/src/decaylanguage/dec/validate.py
+++ b/src/decaylanguage/dec/validate.py
@@ -69,7 +69,7 @@ DLW002 = DiagnosticRule(
 )
 DLW003 = DiagnosticRule(
     "DLW003",
-    "duplicate-cdecay",
+    "decay-cdecay-conflict",
     "A particle is defined with both Decay and CDecay; CDecay is ignored.",
 )
 DLW004 = DiagnosticRule(
@@ -82,13 +82,27 @@ DLW005 = DiagnosticRule(
     "self-conjugate-cdecay",
     "A CDecay statement targets a self-conjugate particle.",
 )
+DLW006 = DiagnosticRule(
+    "DLW006",
+    "duplicate-cdecay",
+    "A particle has multiple CDecay statements; only the first is retained.",
+)
 DLW999 = DiagnosticRule(
     "DLW999",
     "parser-warning",
     "An otherwise unclassified warning emitted by DecFileParser.",
 )
 
-DIAGNOSTIC_RULES = (DLP001, DLW001, DLW002, DLW003, DLW004, DLW005, DLW999)
+DIAGNOSTIC_RULES = (
+    DLP001,
+    DLW001,
+    DLW002,
+    DLW003,
+    DLW004,
+    DLW005,
+    DLW006,
+    DLW999,
+)
 _RULES_BY_CODE = {rule.code: rule for rule in DIAGNOSTIC_RULES}
 _DEFAULT_MAX_DIAGNOSTICS = 100
 
@@ -252,6 +266,12 @@ def _compact_warning_message(rule: DiagnosticRule, message: str) -> str:
         )
         if particle is not None:
             return f"CDecay targets self-conjugate particle: {particle}"
+    if rule is DLW006:
+        particles = _search_message(message, r"with 'CDecay': (?P<particles>.*?)!")
+        if particles is not None:
+            return (
+                f"duplicate CDecay statement(s): {particles}; later statements ignored"
+            )
     return message
 
 

--- a/tests/dec/test_dec.py
+++ b/tests/dec/test_dec.py
@@ -19,6 +19,7 @@ from decaylanguage.dec.dec import (
     DecayNotFound,
     DecFileNotParsed,
     DecFileParser,
+    DuplicateCDecayWarning,
     get_branching_fraction,
     get_decay_mother_name,
     get_final_state_particle_names,
@@ -552,6 +553,24 @@ def test_duplicate_decay_definitions():
     assert p.number_of_decays == 2
 
     assert p.list_decay_mother_names() == ["Sigma(1775)0", "anti-Sigma(1775)0"]
+
+
+def test_duplicate_cdecay_definitions_are_only_applied_once():
+    p = DecFileParser.from_string(
+        """Decay D0
+1.0 K- pi+ PHSP;
+Enddecay
+CDecay anti-D0
+CDecay anti-D0
+End
+"""
+    )
+
+    with pytest.warns(DuplicateCDecayWarning, match="CDecay") as caught:
+        p.parse()
+
+    assert len(caught) == 1
+    assert p.list_decay_mother_names() == ["D0", "anti-D0"]
 
 
 def test_list_decay_modes():

--- a/tests/dec/test_validate.py
+++ b/tests/dec/test_validate.py
@@ -52,7 +52,7 @@ DIR = Path(__file__).parent.resolve()
                 "following particle(s) not found: D0. Skipping creation of these "
                 "copied decay trees."
             ),
-            "DLW002",
+            "DLW006",
             "missing Decay source for CopyDecay: D0",
         ),
         (
@@ -71,7 +71,7 @@ DIR = Path(__file__).parent.resolve()
                 "with 'CDecay': D0! All but the first occurrence will be "
                 "discarded/removed ..."
             ),
-            "DLW006",
+            "DLW002",
             "duplicate CDecay statement(s): D0; later statements ignored",
         ),
         (
@@ -166,7 +166,7 @@ End
 
     diagnostics = validate_files([path])
 
-    assert [diagnostic.code for diagnostic in diagnostics] == ["DLW006"]
+    assert [diagnostic.code for diagnostic in diagnostics] == ["DLW002"]
     assert diagnostics[0].message == (
         "duplicate CDecay statement(s): anti-D0; later statements ignored"
     )
@@ -186,7 +186,7 @@ CDecay anti-D0
 CDecay anti-D0
 End
 """,
-            ["DLW006", "DLW003"],
+            ["DLW002", "DLW003"],
         ),
         (
             """Decay D0
@@ -196,7 +196,7 @@ CDecay B0
 CDecay B0
 End
 """,
-            ["DLW006", "DLW004"],
+            ["DLW002", "DLW004"],
         ),
     ],
 )

--- a/tests/dec/test_validate.py
+++ b/tests/dec/test_validate.py
@@ -39,7 +39,7 @@ DIR = Path(__file__).parent.resolve()
             DuplicateDecayWarning,
             (
                 "The following particle(s) is(are) redefined in the input .dec file "
-                "with 'Decay': D0! All but the first occurrence will be "
+                "with 'Decay': D0! All but the first occurrence(s) will be "
                 "discarded/removed ..."
             ),
             "DLW001",
@@ -68,7 +68,7 @@ DIR = Path(__file__).parent.resolve()
             DuplicateCDecayWarning,
             (
                 "The following particle(s) is(are) redefined in the input .dec file "
-                "with 'CDecay': D0! All but the first occurrence will be "
+                "with 'CDecay': D0! All but the first occurrence(s) will be "
                 "discarded/removed ..."
             ),
             "DLW002",

--- a/tests/dec/test_validate.py
+++ b/tests/dec/test_validate.py
@@ -13,6 +13,7 @@ import pytest
 
 import decaylanguage.dec.validate as validate_module
 from decaylanguage.dec.dec import (
+    DecayAndCDecayWarning,
     DuplicateCDecayWarning,
     DuplicateDecayWarning,
     MissingCDecaySourceWarning,
@@ -55,13 +56,23 @@ DIR = Path(__file__).parent.resolve()
             "missing Decay source for CopyDecay: D0",
         ),
         (
-            DuplicateCDecayWarning,
+            DecayAndCDecayWarning,
             (
                 "The following particles are defined in the input .dec file with both "
                 "'Decay' and 'CDecay': D0! The 'CDecay' definition(s) will be ignored ..."
             ),
             "DLW003",
             "both Decay and CDecay defined: D0; CDecay ignored",
+        ),
+        (
+            DuplicateCDecayWarning,
+            (
+                "The following particle(s) is(are) redefined in the input .dec file "
+                "with 'CDecay': D0! All but the first occurrence will be "
+                "discarded/removed ..."
+            ),
+            "DLW006",
+            "duplicate CDecay statement(s): D0; later statements ignored",
         ),
         (
             MissingCDecaySourceWarning,
@@ -138,6 +149,66 @@ End
 
     assert [diagnostic.code for diagnostic in diagnostics] == ["DLW005"]
     assert diagnostics[0].message == "CDecay targets self-conjugate particle: pi0"
+
+
+def test_validate_files_reports_duplicate_cdecay(tmp_path: Path) -> None:
+    path = tmp_path / "duplicate-cdecay.dec"
+    path.write_text(
+        """Decay D0
+1.0 K- pi+ PHSP;
+Enddecay
+CDecay anti-D0
+CDecay anti-D0
+End
+""",
+        encoding="utf_8",
+    )
+
+    diagnostics = validate_files([path])
+
+    assert [diagnostic.code for diagnostic in diagnostics] == ["DLW006"]
+    assert diagnostics[0].message == (
+        "duplicate CDecay statement(s): anti-D0; later statements ignored"
+    )
+
+
+@pytest.mark.parametrize(
+    ("decay_file", "codes"),
+    [
+        (
+            """Decay D0
+1.0 K- pi+ PHSP;
+Enddecay
+Decay anti-D0
+1.0 K+ pi- PHSP;
+Enddecay
+CDecay anti-D0
+CDecay anti-D0
+End
+""",
+            ["DLW006", "DLW003"],
+        ),
+        (
+            """Decay D0
+1.0 K- pi+ PHSP;
+Enddecay
+CDecay B0
+CDecay B0
+End
+""",
+            ["DLW006", "DLW004"],
+        ),
+    ],
+)
+def test_duplicate_cdecay_is_independent_of_other_cdecay_diagnostics(
+    tmp_path: Path, decay_file: str, codes: list[str]
+) -> None:
+    path = tmp_path / "combined-cdecay-errors.dec"
+    path.write_text(decay_file, encoding="utf_8")
+
+    diagnostics = validate_files([path])
+
+    assert [diagnostic.code for diagnostic in diagnostics] == codes
 
 
 def test_validate_files_can_ignore_exact_code() -> None:


### PR DESCRIPTION
## Summary

This fixes two `CDecay` validation issues discovered while enabling the
DecayLanguage pre-commit hook in LHCb's DecFiles repository:

- [DecFiles !2775](https://gitlab.cern.ch/lhcb-datapkg/Gen/DecFiles/-/merge_requests/2775)
  exposed files that define the same particle with both `Decay` and `CDecay`.
- [DecFiles !2776](https://gitlab.cern.ch/lhcb-datapkg/Gen/DecFiles/-/merge_requests/2776)
  exposed repeated `CDecay` statements, which were not reported separately.

`DLW003` is now named `decay-cdecay-conflict`, matching its existing meaning.
The new `DLW006 duplicate-cdecay` diagnostic reports repeated `CDecay`
statements, and the parser retains only one statement so it cannot create
duplicate charge-conjugate decay trees.

The warning categories, CLI output, tests, and documentation have been updated.

## Validation

- Full test suite: 380 passed, 1 skipped.
- Full pre-commit suite passed.
- Verified against the affected DecFiles corpus.


Let me know what you think @eduardo-rodrigues.