### PR TITLE
Prepare release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Next
+## Version 1.1.1 (2026-08-04)
 
 * Decay-file validation:
   - Renamed diagnostic `DLW003` to `decay-cdecay-conflict` to describe a
@@ -8,6 +8,8 @@
   - Added `DLW002` (`duplicate-cdecay`) for repeated `CDecay` statements;
     later occurrences are now ignored.
   - Renumbered `missing-copydecay-source` to `DLW006`.
+* CI and tests:
+  - Updates and improvements to pre-commit hooks and CI YAML files.
 
 ## Version 1.1.0 (2026-07-27)
 


### PR DESCRIPTION
* Decay-file validation:
  - Renamed diagnostic `DLW003` to `decay-cdecay-conflict` to describe a particle defined by both `Decay` and `CDecay`.
  - Added `DLW002` (`duplicate-cdecay`) for repeated `CDecay` statements; later occurrences are now ignored.
  - Renumbered `missing-copydecay-source` to `DLW006`.
* CI and tests:
  - Updates and improvements to pre-commit hooks and CI YAML files.